### PR TITLE
Support npm@5.7.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea
+node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 node_modules
+iobroker-*.tgz

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 node_modules
 iobroker-*.tgz
+npm-debug.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,31 +14,27 @@ before_install:
   - mkdir node_modules
   - mkdir node_modules/iobroker
   - mv !(node_modules) node_modules/iobroker/
-  - cd node_modules/iobroker/
   - 'if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export CC=clang++; export CXX=clang++; export CXXFLAGS=-std=c++11; fi'
   - 'if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export CXX=g++-4.8; fi'
 install:
-  - export NPMVERSION=$(echo "$($(which npm) -v)"|cut -c1)
-  - export NODEVERSION=$(echo "$($(which node) -v)"|cut -c2)
-  - if [[ $NODEVERSION < 4 ]]; then ! sudo env "PATH=$PATH" $(which npm) install --unsafe-perm; fi
-  - if [[ $NODEVERSION > 3 && $NPMVERSION < 5 ]]; then sudo env "PATH=$PATH" $(which npm) install --unsafe-perm; fi
-  - if [[ $NODEVERSION > 3 && $NPMVERSION > 4 ]]; then ! sudo env "PATH=$PATH" $(which npm) install --unsafe-perm; fi
-  - if [[ $NODEVERSION > 3 && $NPMVERSION > 4 ]]; then sudo env "PATH=$PATH" $(which npm) install --unsafe-perm; fi
+  - cd node_modules/iobroker
+  - sudo chmod +x ./test/travis_install.sh
+  - ./test/travis_install.sh
+  - cd ../..
 before_script:
-  - if [[ $NODEVERSION > 3 ]]; then cd ../..; fi
-  - if [[ $NODEVERSION > 3 ]]; then sudo chmod -R 777 *; fi
-  - if [[ $NODEVERSION > 3 ]]; then ps auxww|grep io; fi
-  - if [[ $NODEVERSION > 3 ]]; then ./iobroker start; fi
-  - if [[ $NODEVERSION > 3 ]]; then cd node_modules/iobroker/; fi
-  - if [[ $NODEVERSION > 3 ]]; then npm install request; fi
-  - if [[ $NODEVERSION > 3 ]]; then npm install mocha; fi
-  - if [[ $NODEVERSION > 3 ]]; then npm install chai; fi
-  - if [[ $NODEVERSION > 3 ]]; then sleep 60; fi
-  - if [[ $NODEVERSION > 3 ]]; then ps auxww|grep io; fi
-  - if [[ $NODEVERSION > 3 ]]; then date; fi
-  - if [[ $NODEVERSION > 3 ]]; then cat ../../log/iobroker*.log; fi
+  - sudo chmod -R 777 *
+  - ps auxww|grep io
+  - ./iobroker start
+  - cd node_modules/iobroker/
+  - npm install request
+  - npm install mocha
+  - npm install chai
+  - sleep 60
+  - ps auxww|grep io
+  - date
+  - cat ../../log/iobroker*.log
 script:
-  - if [[ $NODEVERSION > 3 ]]; then npm test; fi
+  - npm test
 addons:
   apt:
     sources:

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,26 +53,23 @@ before_install:
   - if [[ "$NPM_VER" != "" ]]; then npm i -g npm@$NPM_VER; fi
   - mkdir node_modules
   - mkdir node_modules/iobroker
-  - mv !(node_modules) node_modules/iobroker/
+  - mv !(node_modules|test) node_modules/iobroker/
   - 'if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export CC=clang++; export CXX=clang++; export CXXFLAGS=-std=c++11; fi'
   - 'if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export CXX=g++-4.8; fi'
 install:
-  - cd node_modules/iobroker
   - sudo chmod +x test/travis_install.sh
   # make sure the iob_not_installed file can be created
   - sudo chmod 777 .
-  - cd ../..
-  - node_modules/iobroker/test/travis_install.sh
+  - test/travis_install.sh
   - if [ -e iob_not_installed ]; then echo "ioBroker was not installed (this was expected). Skipping next steps..."; fi
 before_script:
   # only continue tests if ioBroker was actually installed
   - |
     if [ ! -e iob_not_installed ]
     then
-      cd node_modules/iobroker
       sudo chmod +x test/travis_prepareTest.sh
       test/travis_prepareTest.sh
     fi
 script:
   # only continue tests if ioBroker was actually installed
-  - if [ ! -e iob_not_installed ]; then npm test; fi
+  - if [ ! -e iob_not_installed ]; then node_modules/mocha/bin/mocha --exit; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,20 +54,22 @@ before_install:
   - mkdir node_modules
   - mkdir node_modules/iobroker
   - mv !(node_modules) node_modules/iobroker/
-  - cd node_modules/iobroker
   - 'if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export CC=clang++; export CXX=clang++; export CXXFLAGS=-std=c++11; fi'
   - 'if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export CXX=g++-4.8; fi'
 install:
+  - cd node_modules/iobroker
   - sudo chmod +x test/travis_install.sh
   # make sure the iob_not_installed file can be created
   - sudo chmod 777 .
-  - test/travis_install.sh
+  - cd ../..
+  - node_modules/iobroker/test/travis_install.sh
   - if [ -e iob_not_installed ]; then echo "ioBroker was not installed (this was expected). Skipping next steps..."; fi
 before_script:
   # only continue tests if ioBroker was actually installed
   - |
     if [ ! -e iob_not_installed ]
     then
+      cd node_modules/iobroker
       sudo chmod +x test/travis_prepareTest.sh
       test/travis_prepareTest.sh
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,16 +19,21 @@ before_install:
   - 'if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export CXX=g++-4.8; fi'
 install:
   - sudo chmod +x test/travis_install.sh
-  - . test/travis_install.sh
+  # make sure the iob_not_installed file can be created
+  - sudo chmod 777 .
+  - test/travis_install.sh
+  - if [ -e iob_not_installed ]; then echo "ioBroker was not installed (this was expected). Skipping next steps..."; fi
 before_script:
+  # only continue tests if ioBroker was actually installed
   - |
-    if [[ "$IOB_INSTALLED" != "false" ]]
+    if [ ! -e iob_not_installed ]
     then
       sudo chmod +x test/travis_prepareTest.sh
-      . test/travis_prepareTest.sh
+      test/travis_prepareTest.sh
     fi
 script:
-  - if [[ "$IOB_INSTALLED" != "false" ]]; then npm test; fi
+  # only continue tests if ioBroker was actually installed
+  - if [[ ! -e iob_not_installed ]]; then npm test; fi
 addons:
   apt:
     sources:

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ before_script:
     fi
 script:
   # only continue tests if ioBroker was actually installed
-  - if [[ ! -e iob_not_installed ]]; then npm test; fi
+  - if [ ! -e iob_not_installed ]; then npm test; fi
 addons:
   apt:
     sources:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,27 +14,21 @@ before_install:
   - mkdir node_modules
   - mkdir node_modules/iobroker
   - mv !(node_modules) node_modules/iobroker/
+  - cd node_modules/iobroker
   - 'if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export CC=clang++; export CXX=clang++; export CXXFLAGS=-std=c++11; fi'
   - 'if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export CXX=g++-4.8; fi'
 install:
-  - cd node_modules/iobroker
-  - sudo chmod +x ./test/travis_install.sh
-  - ./test/travis_install.sh
-  - cd ../..
+  - sudo chmod +x test/travis_install.sh
+  - . test/travis_install.sh
 before_script:
-  - sudo chmod -R 777 *
-  - ps auxww|grep io
-  - ./iobroker start
-  - cd node_modules/iobroker/
-  - npm install request
-  - npm install mocha
-  - npm install chai
-  - sleep 60
-  - ps auxww|grep io
-  - date
-  - cat ../../log/iobroker*.log
+  - |
+    if [[ "$IOB_INSTALLED" != "false" ]]
+    then
+      sudo chmod +x test/travis_prepareTest.sh
+      . test/travis_prepareTest.sh
+    fi
 script:
-  - npm test
+  - if [[ "$IOB_INSTALLED" != "false" ]]; then npm test; fi
 addons:
   apt:
     sources:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,56 @@
 git:
   submodules: false
-os:
-  - linux
-  - osx
-sudo: required
+
 language: node_js
-node_js:
-  - "0.12"
-  - "4"
-  - "6"
-  - "8"
+
+include: &all
+  sudo: required
+  addons:
+    apt:
+      sources:
+      - ubuntu-toolchain-r-test
+      packages:
+      - g++-4.8
+
+include: &linux
+  <<: *all
+  os: linux
+
+include: &osx
+  <<: *all
+  os: osx
+
+matrix:
+  include:
+    - <<: *linux
+      node_js: 0.12
+    - <<: *linux
+      node_js: 4
+    - <<: *linux
+      node_js: 6
+    - <<: *linux
+      node_js: 8
+    - <<: *linux
+      node_js: 8
+      env:
+        - NPM_VER=5.7.1
+
+    - <<: *osx
+      node_js: 0.12
+    - <<: *osx
+      node_js: 4
+    - <<: *osx
+      node_js: 6
+    - <<: *osx
+      node_js: 8
+    - <<: *osx
+      node_js: 8
+      env:
+        - NPM_VER=5.7.1
+
 before_install:
+  # if we have defined a specific npm version, use that one
+  - if [[ "$NPM_VER" != "" ]]; then npm i -g npm@$NPM_VER; fi
   - mkdir node_modules
   - mkdir node_modules/iobroker
   - mv !(node_modules) node_modules/iobroker/
@@ -34,9 +74,3 @@ before_script:
 script:
   # only continue tests if ioBroker was actually installed
   - if [ ! -e iob_not_installed ]; then npm test; fi
-addons:
-  apt:
-    sources:
-    - ubuntu-toolchain-r-test
-    packages:
-    - g++-4.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,6 @@ install:
   - if [[ $NODEVERSION < 4 ]]; then ! sudo env "PATH=$PATH" $(which npm) install --unsafe-perm; fi
   - if [[ $NODEVERSION > 3 && $NPMVERSION < 5 ]]; then sudo env "PATH=$PATH" $(which npm) install --unsafe-perm; fi
   - if [[ $NODEVERSION > 3 && $NPMVERSION > 4 ]]; then ! sudo env "PATH=$PATH" $(which npm) install --unsafe-perm; fi
-  - if [[ $NODEVERSION > 3 && $NPMVERSION > 4 ]]; then npm install -g npm@4; fi
   - if [[ $NODEVERSION > 3 && $NPMVERSION > 4 ]]; then sudo env "PATH=$PATH" $(which npm) install --unsafe-perm; fi
 before_script:
   - if [[ $NODEVERSION > 3 ]]; then cd ../..; fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,17 +17,17 @@ clone_folder: c:\projects\%APPVEYOR_PROJECT_NAME%\node_modules\iobroker
 install:
   # Get the latest stable version of Node.js or io.js
   - ps: Install-Product node $env:nodejs_version $env:platform
-  - ps: $NpmVersion = (npm -v).Substring(0,1)
+  - ps: $NpmVersion = [System.Version](npm -v)
+  - ps: $NpmUnsupported = $NpmVersion -ge [System.Version]"5.0.0" -and $NpmVersion -lt [System.Version]"5.7.1"
   - ps: $NodeVersion = (node -v).Substring(1,1)
   - ps: Write-Host $NpmVersion
   - ps: Write-Host $NodeVersion
   - ps: if($NodeVersion -eq 0) { $NodeFail = (npm install 2>&1) }
   - ps: if($NodeVersion -eq 0) { Write-Host $NodeFail }
   - ps: if($NodeVersion -eq 0) { if(-Not ($NodeFail -match "ioBroker needs at least nodejs 4.x.")) { exit 1 } }
-  - ps: if($NodeVersion -ne 0 -and $NpmVersion -eq 5) { $NpmFail = (npm install 2>&1) }
-  - ps: if($NodeVersion -ne 0 -and $NpmVersion -eq 5) { Write-Host $NpmFail }
-  - ps: if($NodeVersion -ne 0 -and $NpmVersion -eq 5) { if(-Not ($NpmFail -match "NPM 5 is currently NOT supported!")) { exit 1 } }
-  - ps: if($NodeVersion -ne 0 -and $NpmVersion -eq 5) { npm install -g npm@4 }
+  - ps: if($NodeVersion -ne 0 -and NpmUnsupported) { $NpmFail = (npm install 2>&1) }
+  - ps: if($NodeVersion -ne 0 -and NpmUnsupported) { Write-Host $NpmFail }
+  - ps: if($NodeVersion -ne 0 -and NpmUnsupported) { if(-Not ($NpmFail -match "NPM 5 is only supported starting with version 5.7.1!")) { exit 1 } }
   # install modules
   - ps: if($NodeVersion -ne 0) { npm install }
 # Post-install test scripts.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,9 @@ environment:
     - nodejs_version: "4"
     - nodejs_version: "6"
     - nodejs_version: "8"
+    - nodejs_version: "8"
+      npm_version: "5.7.1"
+
 
 platform:
   - x86
@@ -15,44 +18,30 @@ platform:
 clone_folder: c:\projects\%APPVEYOR_PROJECT_NAME%\node_modules\iobroker
 # Install scripts. (runs after repo cloning)
 install:
-  # Get the latest stable version of Node.js or io.js
-  - ps: Install-Product node $env:nodejs_version $env:platform
-  - ps: $NpmVersion = [System.Version](npm -v)
-  - ps: $NpmUnsupported = $NpmVersion -ge [System.Version]"5.0.0" -and $NpmVersion -lt [System.Version]"5.7.1"
-  - ps: $NodeVersion = (node -v).Substring(1,1)
-  - ps: Write-Host $NpmVersion
-  - ps: Write-Host $NodeVersion
-  - ps: if($NodeVersion -eq 0) { $NodeFail = (npm install 2>&1) }
-  - ps: if($NodeVersion -eq 0) { Write-Host $NodeFail }
-  - ps: if($NodeVersion -eq 0) { if(-Not ($NodeFail -match "ioBroker needs at least nodejs 4.x.")) { exit 1 } }
-  - ps: if($NodeVersion -ne 0 -and NpmUnsupported) { $NpmFail = (npm install 2>&1) }
-  - ps: if($NodeVersion -ne 0 -and NpmUnsupported) { Write-Host $NpmFail }
-  - ps: if($NodeVersion -ne 0 -and NpmUnsupported) { if(-Not ($NpmFail -match "NPM 5 is only supported starting with version 5.7.1!")) { exit 1 } }
-  # install modules
-  - ps: if($NodeVersion -ne 0) { npm install }
+  - ps: cd "c:\projects\$env:APPVEYOR_PROJECT_NAME"
+  # Move test dir to install root, because it will be deleted
+  - ps: Move-Item -Path node_modules\iobroker\test -Destination .
+  - ps: .\test\appveyor_install.ps1
+  - ps: |
+        if ($env:iob_not_installed -eq "true") {
+          echo "ioBroker was not installed (this was expected). Skipping next steps..."
+          Exit-AppVeyorBuild
+        }
 # Post-install test scripts.
 test_script:
-  # Output useful info for debugging.
-  - echo %cd%
-  - node --version
-  - npm --version
-  - ps: if($NodeVersion -ne 0) { iex 'npm install request' }
-  - ps: if($NodeVersion -ne 0) { iex 'npm install mocha' }
-  - ps: if($NodeVersion -ne 0) { iex 'npm install chai' }
-  - ps: if($NodeVersion -ne 0) { iex 'cd ..\..' }
-  - ps: if($NodeVersion -ne 0) { Start-Sleep -s 15 }
-  - ps: if($NodeVersion -ne 0) { iex 'tasklist' }
+  - ps: cd "c:\projects\$env:APPVEYOR_PROJECT_NAME"
+  - ps: npm install request mocha chai --no-optional --save
+  - ps: Start-Sleep -s 15
+  - ps: tasklist
   - serviceIoBroker stop & exit 0
-  - ps: if($NodeVersion -ne 0) { Start-Sleep -s 15 }
+  - ps: Start-Sleep -s 15
   - serviceIoBroker start & exit 0
-  - ps: if($NodeVersion -ne 0) { Start-Sleep -s 60 }
-  - ps: if($NodeVersion -ne 0) { iex 'tasklist' }
-  - ps: if($NodeVersion -ne 0) { iex 'dir .\' }
-  - ps: if($NodeVersion -ne 0) { iex 'dir .\log\' }
-  - ps: if($NodeVersion -ne 0) { iex 'type .\log\iobroker*.log' }
-  - ps: if($NodeVersion -ne 0) { iex 'cd node_modules\iobroker' }
-  # run tests
-  - ps: if($NodeVersion -ne 0) { npm test }
+  - ps: Start-Sleep -s 60
+  - ps: tasklist
+  - dir .\
+  - dir .\log\
+  - type .\log\iobroker*.log & exit 0
+  - node node_modules\mocha\bin\mocha --exit
 
 # Don't actually build.
 build: off

--- a/lib/prepareSetup.js
+++ b/lib/prepareSetup.js
@@ -19,6 +19,15 @@ function checkNpmVersion() {
             console.error('Error trying to check npm version: ' + errResp);
         }
 
+        if (nodeVersion && semver.lt(nodeVersion, "4.0.0")) {
+            console.error('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!');
+            console.error('ioBroker needs at least nodejs 4.x. You have installed ' + nodeVersion);
+            console.error('Please update your nodejs version!');
+            console.error('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!');
+            process.exit(2);
+            return;
+        }
+
         if (!npmVersion) {
             console.error('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!');
             console.error('Aborting install because the npm version could not be checked!');
@@ -26,7 +35,7 @@ function checkNpmVersion() {
             console.error('Use "npm install -g npm@4" or "npm install -g npm@>=5.7.1" to install a supported version.');
             console.error('You need to make sure to repeat this step after installing an update to NodeJS and/or npm');
             console.error('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!');
-            process.exit(1);
+            process.exit(3);
             return;
         }
 
@@ -38,15 +47,7 @@ function checkNpmVersion() {
             console.error('You need to make sure to downgrade again with the above command after you');
             console.error('You need to make sure to repeat this step after installing an update to NodeJS and/or npm');
             console.error('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!');
-            process.exit(1);
-            return;
-        }
-        if (nodeVersion && semver.lt(nodeVersion, "4.0.0")) {
-            console.error('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!');
-            console.error('ioBroker needs at least nodejs 4.x. You have installed ' + nodeVersion);
-            console.error('Please update your nodejs version!');
-            console.error('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!');
-            process.exit(1);
+            process.exit(4);
             return;
         }
         return npmVersion;

--- a/lib/prepareSetup.js
+++ b/lib/prepareSetup.js
@@ -1,0 +1,63 @@
+'use strict';
+
+var fs = require('fs');
+var path = require('path');
+var child_process = require('child_process');
+var semver = require('semver');
+
+function checkNpmVersion() {
+    // Get npm version
+    try {
+        var nodeVersion = semver.valid(process.version);
+        var npmVersion;
+        try {
+            npmVersion = child_process.execSync('npm -v', { encoding: "utf8" });
+            if (npmVersion) npmVersion = semver.valid(npmVersion.trim());
+            console.log('NPM version: ' + npmVersion);
+        } catch (e) {
+            console.error('Error trying to check npm version: ' + errResp);
+        }
+
+        if (!npmVersion) {
+            console.error('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!');
+            console.error('Aborting install because the npm version could not be checked!');
+            console.error('Please check that npm is installed correctly.');
+            console.error('Use "npm install -g npm@4" or "npm install -g npm@>=5.7.1" to install a supported version.');
+            console.error('You need to make sure to repeat this step after installing an update to NodeJS and/or npm');
+            console.error('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!');
+            process.exit(1);
+            return;
+        }
+
+        if (semver.gte(npmVersion, "5.0.0") && semver.lt(npmVersion, "5.7.1")) {
+            console.error('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!');
+            console.error('NPM 5 is only supported starting with version 5.7.1!');
+            console.error('Please use "npm install -g npm@4" to downgrade npm to 4.x or ');
+            console.error('use "npm install -g npm@>=5.7.1" to install a supported version of npm 5!')
+            console.error('You need to make sure to downgrade again with the above command after you');
+            console.error('You need to make sure to repeat this step after installing an update to NodeJS and/or npm');
+            console.error('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!');
+            process.exit(1);
+            return;
+        }
+        if (nodeVersion && semver.lt(nodeVersion, "4.0.0")) {
+            console.error('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!');
+            console.error('ioBroker needs at least nodejs 4.x. You have installed ' + nodeVersion);
+            console.error('Please update your nodejs version!');
+            console.error('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!');
+            process.exit(1);
+            return;
+        }
+        return npmVersion;
+    }
+    catch (e) {
+        console.error('Could not check npm version. Assuming that correct version is installed.');
+    }
+}
+
+if (semver.gte(checkNpmVersion(), "5.0.0")) {
+    // disables NPM's package-lock.json on NPM >= 5 because that creates heaps of problems
+    console.log("npm version >= 5: disabling package-lock")
+    var rootDir = path.normalize(__dirname + '/../../../');
+    fs.writeFileSync(rootDir + '.npmrc', 'package-lock=false', "utf8");
+}

--- a/lib/prepareSetup.js
+++ b/lib/prepareSetup.js
@@ -52,7 +52,8 @@ function checkNpmVersion() {
         return npmVersion;
     }
     catch (e) {
-        console.error('Could not check npm version. Assuming that correct version is installed.');
+        console.error('Could not check npm version: ' + e);
+        console.error('Assuming that correct version is installed.');
     }
 }
 

--- a/lib/prepareSetup.js
+++ b/lib/prepareSetup.js
@@ -4,6 +4,7 @@ var fs = require('fs');
 var path = require('path');
 var child_process = require('child_process');
 var semver = require('semver');
+var os = require('os');
 
 function checkNpmVersion() {
     // Get npm version
@@ -59,5 +60,5 @@ if (semver.gte(checkNpmVersion(), "5.0.0")) {
     // disables NPM's package-lock.json on NPM >= 5 because that creates heaps of problems
     console.log("npm version >= 5: disabling package-lock")
     var rootDir = path.normalize(__dirname + '/../../../');
-    fs.writeFileSync(rootDir + '.npmrc', 'package-lock=false', "utf8");
+    fs.writeFileSync(rootDir + '.npmrc', 'package-lock=false' + os.EOL, "utf8");
 }

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -391,10 +391,10 @@ function npmInstall(packet, isSudo, callback) {
 
     var cmd = '';
     if (platform === 'linux' || platform === 'darwin') {
-        cmd = 'npm install ' + packet + ' --production --save --prefix ' + _path;
+        cmd = 'npm install ' + packet + ' --save --prefix ' + _path;
         if (isSudo) cmd = 'sudo ' + cmd;
     } else {
-        cmd = 'npm install ' + packet + ' --production --save --prefix "' + _path + '"';
+        cmd = 'npm install ' + packet + ' --save --prefix "' + _path + '"';
     }
     console.log(cmd);
     var child = exec(cmd);

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -18,6 +18,7 @@ var yargs = require('yargs')
     .default('states',  '127.0.0.1')
     .default('lang',    'en')
 ;
+var semver = require('semver');
 
 var fs      = require('fs');
 var path    = require('path');
@@ -410,6 +411,10 @@ function npmInstall(packet, isSudo, callback) {
     });
 }
 
+/**
+ * Installs the core iobroker packages
+ * @param {function} callback
+ */
 function setup(callback) {
     var config;
     var platform = require('os').platform();
@@ -425,18 +430,28 @@ function setup(callback) {
             description: 'Automation platform in node.js',
             dependencies: {
                 "iobroker": '~' + ownVersion,
-                "iobroker.discovery": "*",
-                "iobroker.admin": "*",
-                "iobroker.js-controller": "https://github.com/AlCalzone/ioBroker.js-controller/tarball/npm5"
             }
         }, null, 2));
     }
 
-    // install io-brocker.js-controller
+    // if there's a package-lock.json, it has been created by `npm install iobroker` 
+    // and will mess with all future installations if left unchanged
+    // by deleting it, we enable npm to recreate it with the correct content
+    if (fs.existsSync(rootDir + 'package-lock.json')) {
+        try {
+            fs.unlinkSync(rootDir + 'package-lock.json');
+        } catch (e) {
+            console.error("Aborting installation because package-lock.json exists and cannot be deleted.")
+            processExit(1);
+        }
+    }
+
+    // install io-broker.js-controller
     npmInstall('iobroker.discovery', false, function () {
 		npmInstall('iobroker.admin', false, function () {
 			npmInstall('https://github.com/AlCalzone/ioBroker.js-controller/tarball/npm5', false, function () {
-                if (!fs.existsSync(rootDir + 'iobroker-data/iobroker.json')) {
+
+            if (!fs.existsSync(rootDir + 'iobroker-data/iobroker.json')) {
                     if (fs.existsSync(jsDir + 'conf/iobroker-dist.json')) {
                         config = require(jsDir + 'conf/iobroker-dist.json');
                         console.log('creating conf/iobroker.json');
@@ -449,24 +464,6 @@ function setup(callback) {
                     } else {
                         console.log('Could not find "' + jsDir + 'conf/iobroker-dist.json". Possible iobroker.js-controller was not installed');
                     }
-                }
-                try {
-                    if (fs.existsSync(rootDir + 'package.json')) {
-                        var pack = JSON.parse(fs.readFileSync(rootDir + 'package.json').toString());
-                        if (fs.existsSync(rootDir + 'node_modules/iobroker.js-controller/package.json')) {
-                            pack.dependencies['iobroker.js-controller'] = "https://github.com/AlCalzone/ioBroker.js-controller/tarball/npm5";
-                        }
-                        if (fs.existsSync(rootDir + 'node_modules/iobroker.admin/package.json')) {
-                            pack.dependencies['iobroker.admin'] = '~' + JSON.parse(fs.readFileSync(rootDir + 'node_modules/iobroker.admin/package.json').toString()).version;
-                        }
-                        if (fs.existsSync(rootDir + 'node_modules/iobroker.discovery/package.json')) {
-                            pack.dependencies['iobroker.discovery'] = '~' + JSON.parse(fs.readFileSync(rootDir + 'node_modules/iobroker.discovery/package.json').toString()).version;
-                        }
-
-                        fs.writeFileSync(rootDir + 'package.json', JSON.stringify(pack, null, 2));
-                    }
-                } catch (e) {
-                    console.error('Cannot update ' + rootDir + 'package.json: ' + e);
                 }
 
                 try {
@@ -518,10 +515,10 @@ function setChmod(callback) {
 function checkNpmVersion(callback) {
     // Get npm version
     try {
-        var nodeVersion = parseFloat(process.version.substr(1));
+        var nodeVersion = semver.valid(process.version);
 
         var child = child_process.exec('npm -v');
-        var npmVersion = 0;
+        var npmVersion;
         var outResp = '';
         var errResp = '';
         child.stdout.on('data', function (buffer) {
@@ -533,33 +530,35 @@ function checkNpmVersion(callback) {
         child.stdout.on('end', function () {
             if (outResp) {
                 console.log('NPM version: ' + outResp);
-                npmVersion = parseFloat(outResp.split('\n')[0]);
+                npmVersion = semver.valid(outResp.split('\n')[0], true);
             }
             if (errResp) {
                 console.error('Error trying to check npm version: ' + errResp);
             }
 
-            if (npmVersion && false && npmVersion >= 5.0) {
-                console.error('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!');
-                console.error('NPM 5 is currently NOT supported!');
-                console.error('Please use "npm install -g npm@4" to downgrade npm to 4.x and try again.');
-                console.error('You need to make sure to downgrade again with the above command after you');
-                console.error('installed an update to nodejs/npm!');
-                console.error('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!');
-                processExit(1);
-                return;
-            }
             if (!npmVersion) {
                 console.error('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!');
-                console.error('Could not check npm version. Abort install. Please check that npm is installed correctly.');
-                console.error('Please use "npm install -g npm@4" to install npm 4.x and try again.');
-                console.error('You need to make sure to downgrade to 4.x again with the above command after you');
-                console.error('installed an update to nodejs/npm!');
+                console.error('Aborting install because the npm version could not be checked!');
+                console.error('Please check that npm is installed correctly.');
+                console.error('Use "npm install -g npm@4" or "npm install -g npm@>=5.7.1" to install a supported version.');
+                console.error('You need to make sure to repeat this step after installing an update to NodeJS and/or npm');
                 console.error('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!');
                 processExit(1);
                 return;
             }
-            if (nodeVersion && nodeVersion < 4.0) {
+
+            if (semver.gte(npmVersion, "5.0.0") && semver.lt(npmVersion, "5.7.1")) {
+                console.error('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!');
+                console.error('NPM 5 is only supported starting with version 5.7.1!');
+                console.error('Please use "npm install -g npm@4" to downgrade npm to 4.x or ');
+                console.error('use "npm install -g npm@>=5.7.1" to install a supported version of npm 5!')
+                console.error('You need to make sure to downgrade again with the above command after you');
+                console.error('You need to make sure to repeat this step after installing an update to NodeJS and/or npm');
+                console.error('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!');
+                processExit(1);
+                return;
+            }
+            if (nodeVersion && semver.lt(nodeVersion, "4.0.0")) {
                 console.error('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!');
                 console.error('ioBroker needs at least nodejs 4.x. You have installed ' + nodeVersion);
                 console.error('Please update your nodejs version!');

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -1,3 +1,5 @@
+//@ts-check
+
 /**
  *
  *  ioBroker installer from npm
@@ -15,15 +17,15 @@ var yargs = require('yargs')
     .usage('Commands:\n' +
         '$0 [--objects <host>] [--states <host>] [custom]\n')
     .default('objects', '127.0.0.1')
-    .default('states',  '127.0.0.1')
-    .default('lang',    'en')
-;
+    .default('states', '127.0.0.1')
+    .default('lang', 'en')
+    ;
 var semver = require('semver');
 
-var fs      = require('fs');
-var path    = require('path');
+var fs = require('fs');
+var path = require('path');
 var rootDir = path.normalize(__dirname + '/../../../');
-var jsDir   = rootDir + 'node_modules/iobroker.js-controller/';
+var jsDir = rootDir + 'node_modules/iobroker.js-controller/';
 var child_process = require('child_process');
 
 // Save objects before exit
@@ -53,14 +55,14 @@ function copyFile(source, target, cb) {
     var cbCalled = false;
 
     var rd = fs.createReadStream(source);
-    rd.on('error', function(err) {
+    rd.on('error', function (err) {
         done(err);
     });
     var wr = fs.createWriteStream(target);
-    wr.on('error', function(err) {
+    wr.on('error', function (err) {
         done(err);
     });
-    wr.on('close', function(ex) {
+    wr.on('close', function (ex) {
         done();
     });
     rd.pipe(wr);
@@ -111,7 +113,7 @@ function setupWindows(callback) {
 }
 
 function setupFreeBSD(callback) {
-    fs.writeFileSync(rootDir + 'iobroker', "node node_modules/iobroker.js-controller/iobroker.js $1 $2 $3 $4 $5", {mode: '755'});
+    fs.writeFileSync(rootDir + 'iobroker', "node node_modules/iobroker.js-controller/iobroker.js $1 $2 $3 $4 $5", { mode: '755' });
     console.log('Write "service iobroker start" to start the ioBroker');
     try {
         if (!fs.existsSync(jsDir + 'iobroker')) {
@@ -143,21 +145,21 @@ function setupFreeBSD(callback) {
     text += 'bash ' + path.normalize(__dirname + '/../install/freebsd/install.sh') + '\n';
 
     try {
-        fs.writeFileSync(rootDir + 'install.sh', text, {mode: 511});
+        fs.writeFileSync(rootDir + 'install.sh', text, { mode: 511 });
     } catch (e) {
 
     }
 
-    try{
+    try {
         // check if /etc/init.d/ exists
         if (fs.existsSync('/usr/local/bin')) {
-            fs.writeFileSync('/usr/local/bin/iobroker', 'node ' + home.join('/') + '/node_modules/iobroker.js-controller/iobroker.js $1 $2 $3 $4 $5', {mode: "755"});
+            fs.writeFileSync('/usr/local/bin/iobroker', 'node ' + home.join('/') + '/node_modules/iobroker.js-controller/iobroker.js $1 $2 $3 $4 $5', { mode: "755" });
             fs.chmodSync('/usr/bin/iobroker', '755');
         }
     } catch (e) {
         console.warn('Cannot create file /usr/local/bin/iobroker!. Non critical');
         // create files for manual coping
-        fs.writeFileSync(__dirname + '/../install/iobroker', 'node ' + home.join('/') + '/node_modules/iobroker.js-controller/iobroker.js $1 $2 $3 $4 $5', {mode: "755"});
+        fs.writeFileSync(__dirname + '/../install/iobroker', 'node ' + home.join('/') + '/node_modules/iobroker.js-controller/iobroker.js $1 $2 $3 $4 $5', { mode: "755" });
         console.log('');
         console.log('-----------------------------------------------------');
         console.log('You can manually copy file into /usr/local/bin/. Just write:');
@@ -172,7 +174,7 @@ function setupFreeBSD(callback) {
         var txt = fs.readFileSync(__dirname + '/../install/freebsd/iobroker');
         txt = txt.toString().replace(/@@PATH@@/g, _path);
         txt = txt.toString().replace(/@@HOME@@/g, home.join('/'));
-        fs.writeFileSync(__dirname + '/../install/freebsd/iobroker', txt, {mode: '755'});
+        fs.writeFileSync(__dirname + '/../install/freebsd/iobroker', txt, { mode: '755' });
         fs.chmodSync(__dirname + '/../install/freebsd/iobroker', '755');
 
         // copy iobroker from install/freebsd to /usr/local/etc/rc.d
@@ -180,7 +182,7 @@ function setupFreeBSD(callback) {
             txt = fs.readFileSync(__dirname + '/../install/freebsd/install.sh');
             txt = txt.toString().replace(/@@PATH@@/g, _path);
 
-            fs.writeFileSync(__dirname + '/../install/freebsd/install.sh', txt, {mode: '755'});
+            fs.writeFileSync(__dirname + '/../install/freebsd/install.sh', txt, { mode: '755' });
             fs.chmodSync(__dirname + '/../install/freebsd/install.sh', '755');
 
             var exec = require('child_process').exec;
@@ -213,7 +215,7 @@ function setupFreeBSD(callback) {
 }
 
 function setupLinux(callback) {
-    fs.writeFileSync(rootDir + 'iobroker', "node node_modules/iobroker.js-controller/iobroker.js $1 $2 $3 $4 $5", {mode: '777'});
+    fs.writeFileSync(rootDir + 'iobroker', "node node_modules/iobroker.js-controller/iobroker.js $1 $2 $3 $4 $5", { mode: '777' });
     console.log('Write "./iobroker start" to start the ioBroker');
     try {
         if (!fs.existsSync(jsDir + 'iobroker')) {
@@ -245,21 +247,21 @@ function setupLinux(callback) {
     text += 'sudo bash ' + path.normalize(__dirname + '/../install/linux/install.sh') + '\n';
 
     try {
-        fs.writeFileSync(rootDir + 'install.sh', text, {mode: 511});
+        fs.writeFileSync(rootDir + 'install.sh', text, { mode: 511 });
     } catch (e) {
 
     }
 
-    try{
+    try {
         // check if /etc/init.d/ exists
         if (fs.existsSync('/usr/bin')) {
-            fs.writeFileSync('/usr/bin/iobroker', 'node ' + home.join('/') + '/node_modules/iobroker.js-controller/iobroker.js $1 $2 $3 $4 $5', {mode: "777"});
+            fs.writeFileSync('/usr/bin/iobroker', 'node ' + home.join('/') + '/node_modules/iobroker.js-controller/iobroker.js $1 $2 $3 $4 $5', { mode: "777" });
             fs.chmodSync('/usr/bin/iobroker', '777');
         }
     } catch (e) {
         console.warn('Cannot create file /usr/bin/iobroker!. Non critical');
         // create files for manual coping
-        fs.writeFileSync(__dirname + '/../install/iobroker', 'node ' + home.join('/') + '/node_modules/iobroker.js-controller/iobroker.js $1 $2 $3 $4 $5', {mode: "777"});
+        fs.writeFileSync(__dirname + '/../install/iobroker', 'node ' + home.join('/') + '/node_modules/iobroker.js-controller/iobroker.js $1 $2 $3 $4 $5', { mode: "777" });
         console.log('');
         console.log('-----------------------------------------------------');
         console.log('You can manually copy file into /usr/bin/. Just write:');
@@ -276,7 +278,7 @@ function setupLinux(callback) {
         var txt = fs.readFileSync(__dirname + '/../install/freebsd/iobroker');
         txt = txt.toString().replace(/@@PATH@@/g, _path);
         txt = txt.toString().replace(/@@HOME@@/g, home.join('/'));
-        fs.writeFileSync(__dirname + '/../install/freebsd/iobroker', txt, {mode: '755'});
+        fs.writeFileSync(__dirname + '/../install/freebsd/iobroker', txt, { mode: '755' });
         fs.chmodSync(__dirname + '/../install/freebsd/iobroker', '755');
 
         // copy iobroker from install/freebsd to /usr/local/etc/rc.d
@@ -284,7 +286,7 @@ function setupLinux(callback) {
             txt = fs.readFileSync(__dirname + '/../install/freebsd/install.sh');
             txt = txt.toString().replace(/@@PATH@@/g, _path);
 
-            fs.writeFileSync(__dirname + '/../install/freebsd/install.sh', txt, {mode: '755'});
+            fs.writeFileSync(__dirname + '/../install/freebsd/install.sh', txt, { mode: '755' });
             fs.chmodSync(__dirname + '/../install/freebsd/install.sh', '755');
 
             var exec = require('child_process').exec;
@@ -323,7 +325,7 @@ function setupLinux(callback) {
         var txt = fs.readFileSync(__dirname + '/../install/linux/iobroker.sh');
         txt = txt.toString().replace(/@@PATH@@/g, _path);
         txt = txt.toString().replace(/@@HOME@@/g, home.join('/'));
-        fs.writeFileSync(__dirname + '/../install/linux/iobroker.sh', txt, {mode: '777'});
+        fs.writeFileSync(__dirname + '/../install/linux/iobroker.sh', txt, { mode: '777' });
         fs.chmodSync(__dirname + '/../install/linux/iobroker.sh', '777');
 
         // copy iobroker.sh from install/linux to /etc/init.d/
@@ -331,7 +333,7 @@ function setupLinux(callback) {
             txt = fs.readFileSync(__dirname + '/../install/linux/install.sh');
             txt = txt.toString().replace(/@@PATH@@/g, _path);
 
-            fs.writeFileSync(__dirname + '/../install/linux/install.sh', txt, {mode: '777'});
+            fs.writeFileSync(__dirname + '/../install/linux/install.sh', txt, { mode: '777' });
             fs.chmodSync(__dirname + '/../install/linux/install.sh', '777');
 
             var exec = require('child_process').exec;
@@ -380,12 +382,6 @@ var gIsSudo = false;
 
 function npmInstall(packet, isSudo, callback) {
     var platform = require('os').platform();
-    // install from npm
-    // Calculate directory
-    var parts = __dirname.replace(/\\/g, '/').split('/');
-    parts.splice(parts.length - 3, 3);
-    var _path = parts.join('/');
-
     if (isSudo) gIsSudo = true;
 
     var cmd = 'npm install ' + packet + ' --production --save';
@@ -394,11 +390,12 @@ function npmInstall(packet, isSudo, callback) {
     }
 
     console.log(cmd);
-    var child = child_process.exec(cmd, {cwd: _path});
+    var child = child_process.exec(cmd, {cwd: rootDir});
+    child.stdout.pipe(process.stdout);
     child.stderr.pipe(process.stdout);
     child.on('exit', function () {
         // Check if exist
-        if ((platform === 'linux' || platform === 'darwin') && !isSudo && !fs.existsSync(_path + '/node_modules/' + packet)) {
+        if ((platform === 'linux' || platform === 'darwin') && !isSudo && !fs.existsSync(path.join(rootDir, '/node_modules/', packet))) {
             console.log('Cannot install as normal user. Try sudo...');
             // try sudo mode
             npmInstall(packet, true, callback);
@@ -426,7 +423,7 @@ function setup(callback) {
             private: true,
             description: 'Automation platform in node.js',
             dependencies: {
-                "iobroker": '~' + ownVersion,
+                "iobroker": "https://github.com/AlCalzone/ioBroker/tarball/npm5-try2"
             }
         }, null, 2));
     }
@@ -448,7 +445,7 @@ function setup(callback) {
         npmInstall('iobroker.admin', false, function () {
             npmInstall('https://github.com/AlCalzone/ioBroker.js-controller/tarball/npm5', false, function () {
 
-            if (!fs.existsSync(rootDir + 'iobroker-data/iobroker.json')) {
+                if (!fs.existsSync(rootDir + 'iobroker-data/iobroker.json')) {
                     if (fs.existsSync(jsDir + 'conf/iobroker-dist.json')) {
                         config = require(jsDir + 'conf/iobroker-dist.json');
                         console.log('creating conf/iobroker.json');
@@ -466,9 +463,6 @@ function setup(callback) {
                 try {
                     // Create iobroker.sh and bat
                     if (!fs.existsSync(rootDir + 'log')) fs.mkdirSync(rootDir + 'log');
-
-                    // update package.json
-
 
                     if (platform === 'linux' || platform === 'darwin') {
                         setupLinux(callback);

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -379,9 +379,9 @@ function setupLinux(callback) {
 var gIsSudo = false;
 
 function npmInstall(packet, isSudo, callback) {
-	var exec = require('child_process').exec;
+    var exec = require('child_process').exec;
     var platform = require('os').platform();
-	// install from npm
+    // install from npm
     // Calculate directory
     var parts = __dirname.replace(/\\/g, '/').split('/');
     parts.splice(parts.length - 3, 3);
@@ -391,15 +391,15 @@ function npmInstall(packet, isSudo, callback) {
 
     var cmd = '';
     if (platform === 'linux' || platform === 'darwin') {
-        cmd = 'npm install ' + packet + ' --save --prefix ' + _path;
+        cmd = 'npm install ' + packet + ' --production --save --prefix ' + _path;
         if (isSudo) cmd = 'sudo ' + cmd;
     } else {
-        cmd = 'npm install ' + packet + ' --save --prefix "' + _path + '"';
+        cmd = 'npm install ' + packet + ' --production --save --prefix "' + _path + '"';
     }
     console.log(cmd);
     var child = exec(cmd);
-	child.stderr.pipe(process.stdout);
-	child.on('exit', function () {
+    child.stderr.pipe(process.stdout);
+    child.on('exit', function () {
         // Check if exist
         if ((platform === 'linux' || platform === 'darwin') && !isSudo && !fs.existsSync(_path + '/node_modules/' + packet)) {
             console.log('Cannot install as normal user. Try sudo...');
@@ -448,8 +448,8 @@ function setup(callback) {
 
     // install io-broker.js-controller
     npmInstall('iobroker.discovery', false, function () {
-		npmInstall('iobroker.admin', false, function () {
-			npmInstall('https://github.com/AlCalzone/ioBroker.js-controller/tarball/npm5', false, function () {
+        npmInstall('iobroker.admin', false, function () {
+            npmInstall('https://github.com/AlCalzone/ioBroker.js-controller/tarball/npm5', false, function () {
 
             if (!fs.existsSync(rootDir + 'iobroker-data/iobroker.json')) {
                     if (fs.existsSync(jsDir + 'conf/iobroker-dist.json')) {
@@ -484,8 +484,8 @@ function setup(callback) {
                     console.log('Non-critical error: ' + e.message);
                 }
             });
-		});
-	});
+        });
+    });
 }
 
 function setChmod(callback) {
@@ -512,71 +512,4 @@ function setChmod(callback) {
     }
 }
 
-function checkNpmVersion(callback) {
-    // Get npm version
-    try {
-        var nodeVersion = semver.valid(process.version);
-
-        var child = child_process.exec('npm -v');
-        var npmVersion;
-        var outResp = '';
-        var errResp = '';
-        child.stdout.on('data', function (buffer) {
-            outResp += buffer.toString();
-        });
-        child.stderr.on('data', function (buffer) {
-            errResp += buffer.toString();
-        });
-        child.stdout.on('end', function () {
-            if (outResp) {
-                console.log('NPM version: ' + outResp);
-                npmVersion = semver.valid(outResp.split('\n')[0], true);
-            }
-            if (errResp) {
-                console.error('Error trying to check npm version: ' + errResp);
-            }
-
-            if (!npmVersion) {
-                console.error('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!');
-                console.error('Aborting install because the npm version could not be checked!');
-                console.error('Please check that npm is installed correctly.');
-                console.error('Use "npm install -g npm@4" or "npm install -g npm@>=5.7.1" to install a supported version.');
-                console.error('You need to make sure to repeat this step after installing an update to NodeJS and/or npm');
-                console.error('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!');
-                processExit(1);
-                return;
-            }
-
-            if (semver.gte(npmVersion, "5.0.0") && semver.lt(npmVersion, "5.7.1")) {
-                console.error('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!');
-                console.error('NPM 5 is only supported starting with version 5.7.1!');
-                console.error('Please use "npm install -g npm@4" to downgrade npm to 4.x or ');
-                console.error('use "npm install -g npm@>=5.7.1" to install a supported version of npm 5!')
-                console.error('You need to make sure to downgrade again with the above command after you');
-                console.error('You need to make sure to repeat this step after installing an update to NodeJS and/or npm');
-                console.error('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!');
-                processExit(1);
-                return;
-            }
-            if (nodeVersion && semver.lt(nodeVersion, "4.0.0")) {
-                console.error('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!');
-                console.error('ioBroker needs at least nodejs 4.x. You have installed ' + nodeVersion);
-                console.error('Please update your nodejs version!');
-                console.error('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!');
-                processExit(1);
-                return;
-            }
-            callback();
-        });
-    }
-    catch (e) {
-        console.error('Could not check npm version. Assuming that correct version is installed.');
-    }
-}
-
-
-checkNpmVersion(function() {
-    setup(function (code) {
-    	processExit(code);
-    });
-});
+setup(processExit);

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -422,7 +422,7 @@ function setup(callback) {
             name: 'iobroker.inst',
             version: ownVersion,
             private: true,
-            description: 'Automation platfrom in node.js',
+            description: 'Automation platform in node.js',
             dependencies: {
                 "iobroker": '~' + ownVersion,
                 "iobroker.discovery": "*",
@@ -539,7 +539,7 @@ function checkNpmVersion(callback) {
                 console.error('Error trying to check npm version: ' + errResp);
             }
 
-            if (npmVersion && npmVersion >= 5.0) {
+            if (npmVersion && false && npmVersion >= 5.0) {
                 console.error('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!');
                 console.error('NPM 5 is currently NOT supported!');
                 console.error('Please use "npm install -g npm@4" to downgrade npm to 4.x and try again.');
@@ -551,9 +551,9 @@ function checkNpmVersion(callback) {
             }
             if (!npmVersion) {
                 console.error('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!');
-                console.error('Could not check npm version. Abort install. Please check that npm is installed corrctly.');
-                console.error('Please use "npm install -g npm@4" to installe npm to 4.x and try again.');
-                console.error('You need to make sure to downgrade again with the above command after you');
+                console.error('Could not check npm version. Abort install. Please check that npm is installed correctly.');
+                console.error('Please use "npm install -g npm@4" to install npm 4.x and try again.');
+                console.error('You need to make sure to downgrade to 4.x again with the above command after you');
                 console.error('installed an update to nodejs/npm!');
                 console.error('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!');
                 processExit(1);

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -380,6 +380,12 @@ function setupLinux(callback) {
 }
 var gIsSudo = false;
 
+/**
+ * Installs an npm packet
+ * @param {string} packet The packet (or packet url) to install
+ * @param {boolean} isSudo Whether the installation should be executed with or without `sudo`
+ * @param {function} callback Called after the installation is finished
+ */
 function npmInstall(packet, isSudo, callback) {
     var platform = require('os').platform();
     if (isSudo) gIsSudo = true;
@@ -394,8 +400,15 @@ function npmInstall(packet, isSudo, callback) {
     child.stdout.pipe(process.stdout);
     child.stderr.pipe(process.stdout);
     child.on('exit', function () {
-        // Check if exist
-        if ((platform === 'linux' || platform === 'darwin') && !isSudo && !fs.existsSync(path.join(rootDir, '/node_modules/', packet))) {
+        var packetFolder = packet.toLowerCase();
+        // clean up packet directory
+        if (packetFolder.indexOf("github.com") > -1) {
+            packetFolder = /github\.com\/\w+\/([^\/]+)\//.exec(packetFolder)[1]
+        }
+        packetFolder = path.join(rootDir, '/node_modules/', packetFolder);
+        console.log("packet folder is: " + packetFolder + " | exists: " + fs.existsSync(packetFolder));
+        // Check if the packet was installed
+        if ((platform === 'linux' || platform === 'darwin') && !isSudo && !fs.existsSync(packetFolder)) {
             console.log('Cannot install as normal user. Try sudo...');
             // try sudo mode
             npmInstall(packet, true, callback);

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -441,40 +441,38 @@ function setup(callback) {
     }
 
     // install io-broker.js-controller
-    npmInstall('iobroker.discovery', false, function () {
-        npmInstall('iobroker.admin', false, function () {
-            npmInstall('https://github.com/AlCalzone/ioBroker.js-controller/tarball/npm5', false, function () {
+    npmInstall('https://github.com/AlCalzone/ioBroker.js-controller/tarball/npm5', false, function () {
+        npmInstall('iobroker.discovery', false, function () {
 
-                if (!fs.existsSync(rootDir + 'iobroker-data/iobroker.json')) {
-                    if (fs.existsSync(jsDir + 'conf/iobroker-dist.json')) {
-                        config = require(jsDir + 'conf/iobroker-dist.json');
-                        console.log('creating conf/iobroker.json');
-                        config.objects.host = yargs.argv.objects || '127.0.0.1';
-                        config.states.host  = yargs.argv.states  || '127.0.0.1';
-                        config.dataDir = tools.getDefaultDataDir();
-                        mkpathSync(__dirname + '/', '../' + config.dataDir);
-                        // Create default data dir
-                        fs.writeFileSync(tools.getConfigFileName(), JSON.stringify(config, null, 2));
-                    } else {
-                        console.log('Could not find "' + jsDir + 'conf/iobroker-dist.json". Possible iobroker.js-controller was not installed');
-                    }
+            if (!fs.existsSync(rootDir + 'iobroker-data/iobroker.json')) {
+                if (fs.existsSync(jsDir + 'conf/iobroker-dist.json')) {
+                    config = require(jsDir + 'conf/iobroker-dist.json');
+                    console.log('creating conf/iobroker.json');
+                    config.objects.host = yargs.argv.objects || '127.0.0.1';
+                    config.states.host  = yargs.argv.states  || '127.0.0.1';
+                    config.dataDir = tools.getDefaultDataDir();
+                    mkpathSync(__dirname + '/', '../' + config.dataDir);
+                    // Create default data dir
+                    fs.writeFileSync(tools.getConfigFileName(), JSON.stringify(config, null, 2));
+                } else {
+                    console.log('Could not find "' + jsDir + 'conf/iobroker-dist.json". Possible iobroker.js-controller was not installed');
                 }
+            }
 
-                try {
-                    // Create iobroker.sh and bat
-                    if (!fs.existsSync(rootDir + 'log')) fs.mkdirSync(rootDir + 'log');
+            try {
+                // Create iobroker.sh and bat
+                if (!fs.existsSync(rootDir + 'log')) fs.mkdirSync(rootDir + 'log');
 
-                    if (platform === 'linux' || platform === 'darwin') {
-                        setupLinux(callback);
-                    } else if (platform.match(/^win/)) {
-                        setupWindows(callback);
-                    } else if (platform === 'freebsd') {
-                        setupFreeBSD(callback);
-                    }
-                } catch (e) {
-                    console.log('Non-critical error: ' + e.message);
+                if (platform === 'linux' || platform === 'darwin') {
+                    setupLinux(callback);
+                } else if (platform.match(/^win/)) {
+                    setupWindows(callback);
+                } else if (platform === 'freebsd') {
+                    setupFreeBSD(callback);
                 }
-            });
+            } catch (e) {
+                console.log('Non-critical error: ' + e.message);
+            }
         });
     });
 }

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -456,14 +456,14 @@ function setup(callback) {
     npmInstall('iobroker.discovery', false, function () {
         npmInstall('https://github.com/AlCalzone/ioBroker.js-controller/tarball/npm5', false, function () {
 
-            if (!fs.existsSync(rootDir + 'iobroker-data/iobroker.json')) {
-                if (fs.existsSync(jsDir + 'conf/iobroker-dist.json')) {
-                    config = require(jsDir + 'conf/iobroker-dist.json');
+            if (!fs.existsSync(path.join(rootDir, 'iobroker-data', 'iobroker.json'))) {
+                if (fs.existsSync(path.join(jsDir, 'conf', 'iobroker-dist.json'))) {
+                    config = require(path.join(jsDir, 'conf', 'iobroker-dist.json'));
                     console.log('creating conf/iobroker.json');
                     config.objects.host = yargs.argv.objects || '127.0.0.1';
                     config.states.host  = yargs.argv.states  || '127.0.0.1';
                     config.dataDir = tools.getDefaultDataDir();
-                    mkpathSync(__dirname + '/', '../' + config.dataDir);
+                    mkpathSync(path.join(__dirname, '../', config.dataDir));
                     // Create default data dir
                     fs.writeFileSync(tools.getConfigFileName(), JSON.stringify(config, null, 2));
                 } else {

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -436,7 +436,6 @@ function setup(callback) {
             private: true,
             description: 'Automation platform in node.js',
             dependencies: {
-                "iobroker": "https://github.com/AlCalzone/ioBroker/tarball/npm5-try2"
             }
         }, null, 2));
     }

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -436,6 +436,7 @@ function setup(callback) {
             private: true,
             description: 'Automation platform in node.js',
             dependencies: {
+                iobroker: ownVersion
             }
         }, null, 2));
     }
@@ -454,7 +455,7 @@ function setup(callback) {
 
     // install io-broker.js-controller
     npmInstall('iobroker.discovery', false, function () {
-        npmInstall('https://github.com/AlCalzone/ioBroker.js-controller/tarball/npm5', false, function () {
+        npmInstall('iobroker.js-controller', false, function () {
 
             if (!fs.existsSync(path.join(rootDir, 'iobroker-data', 'iobroker.json'))) {
                 if (fs.existsSync(path.join(jsDir, 'conf', 'iobroker-dist.json'))) {

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -453,8 +453,8 @@ function setup(callback) {
     }
 
     // install io-broker.js-controller
-    npmInstall('https://github.com/AlCalzone/ioBroker.js-controller/tarball/npm5', false, function () {
-        npmInstall('iobroker.discovery', false, function () {
+    npmInstall('iobroker.discovery', false, function () {
+        npmInstall('https://github.com/AlCalzone/ioBroker.js-controller/tarball/npm5', false, function () {
 
             if (!fs.existsSync(rootDir + 'iobroker-data/iobroker.json')) {
                 if (fs.existsSync(jsDir + 'conf/iobroker-dist.json')) {

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -379,7 +379,6 @@ function setupLinux(callback) {
 var gIsSudo = false;
 
 function npmInstall(packet, isSudo, callback) {
-    var exec = require('child_process').exec;
     var platform = require('os').platform();
     // install from npm
     // Calculate directory
@@ -389,15 +388,13 @@ function npmInstall(packet, isSudo, callback) {
 
     if (isSudo) gIsSudo = true;
 
-    var cmd = '';
-    if (platform === 'linux' || platform === 'darwin') {
-        cmd = 'npm install ' + packet + ' --production --save --prefix ' + _path;
-        if (isSudo) cmd = 'sudo ' + cmd;
-    } else {
-        cmd = 'npm install ' + packet + ' --production --save --prefix "' + _path + '"';
+    var cmd = 'npm install ' + packet + ' --production --save';
+    if (isSudo && (platform === 'linux' || platform === 'darwin')) {
+        cmd = 'sudo ' + cmd;
     }
+
     console.log(cmd);
-    var child = exec(cmd);
+    var child = child_process.exec(cmd, {cwd: _path});
     child.stderr.pipe(process.stdout);
     child.on('exit', function () {
         // Check if exist

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -454,7 +454,7 @@ function setup(callback) {
                     if (fs.existsSync(rootDir + 'package.json')) {
                         var pack = JSON.parse(fs.readFileSync(rootDir + 'package.json').toString());
                         if (fs.existsSync(rootDir + 'node_modules/iobroker.js-controller/package.json')) {
-                            pack.dependencies['iobroker.js-controller'] = '~' + JSON.parse(fs.readFileSync(rootDir + 'node_modules/iobroker.js-controller/package.json').toString()).version;
+                            pack.dependencies['iobroker.js-controller'] = "https://github.com/AlCalzone/ioBroker.js-controller/tarball/npm5";
                         }
                         if (fs.existsSync(rootDir + 'node_modules/iobroker.admin/package.json')) {
                             pack.dependencies['iobroker.admin'] = '~' + JSON.parse(fs.readFileSync(rootDir + 'node_modules/iobroker.admin/package.json').toString()).version;

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -427,7 +427,7 @@ function setup(callback) {
                 "iobroker": '~' + ownVersion,
                 "iobroker.discovery": "*",
                 "iobroker.admin": "*",
-                "iobroker.js-controller": "*"
+                "iobroker.js-controller": "https://github.com/AlCalzone/ioBroker.js-controller/tarball/npm5"
             }
         }, null, 2));
     }
@@ -435,7 +435,7 @@ function setup(callback) {
     // install io-brocker.js-controller
     npmInstall('iobroker.discovery', false, function () {
 		npmInstall('iobroker.admin', false, function () {
-			npmInstall('iobroker.js-controller', false, function () {
+			npmInstall('https://github.com/AlCalzone/ioBroker.js-controller/tarball/npm5', false, function () {
                 if (!fs.existsSync(rootDir + 'iobroker-data/iobroker.json')) {
                     if (fs.existsSync(jsDir + 'conf/iobroker-dist.json')) {
                         config = require(jsDir + 'conf/iobroker-dist.json');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iobroker",
-  "version": "1.0.8",
+  "version": "1.1.0",
   "engines": {
     "node": ">=0.8"
   },
@@ -38,7 +38,8 @@
   "author": "bluefox <dogafox@gmail.com>",
   "contributors": [
     "bluefox <dogafox@gmail.com>",
-    "hobbyquaker"
+    "hobbyquaker",
+    "AlCalzone <d.griesel@gmx.net>"
   ],
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -48,8 +48,7 @@
     "unsafe-perm": true
   },
   "scripts": {
-    "preinstall": "node lib/prepareSetup.js",
-    "install": "node lib/setup.js",
+    "install": "node lib/prepareSetup.js & node lib/setup.js",
     "test": "node node_modules/mocha/bin/mocha --exit"
   },
   "main": "lib/setup.js",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "unsafe-perm": true
   },
   "scripts": {
-    "install": "node lib/prepareSetup.js & node lib/setup.js",
+    "install": "node lib/prepareSetup.js && node lib/setup.js",
     "test": "node node_modules/mocha/bin/mocha --exit"
   },
   "main": "lib/setup.js",

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "engines": {
     "node": ">=0.8"
   },
-  "optionalDependencies": {
-  },
+  "optionalDependencies": {},
   "dependencies": {
+    "semver": "^5.5.0",
     "yargs": "^7.0.2"
   },
   "homepage": "http://iobroker.net",
@@ -48,6 +48,7 @@
     "unsafe-perm": true
   },
   "scripts": {
+    "preinstall": "node lib/prepareSetup.js",
     "install": "node lib/setup.js",
     "test": "node node_modules/mocha/bin/mocha --exit"
   },

--- a/package.json
+++ b/package.json
@@ -53,9 +53,5 @@
   },
   "main": "lib/setup.js",
   "license": "MIT",
-  "devDependencies": {
-    "chai": "^4.1.2",
-    "mocha": "^5.0.1",
-    "request": "^2.83.0"
-  }
+  "devDependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -52,5 +52,10 @@
     "test": "node node_modules/mocha/bin/mocha --exit"
   },
   "main": "lib/setup.js",
-  "license": "MIT"
+  "license": "MIT",
+  "devDependencies": {
+    "chai": "^4.1.2",
+    "mocha": "^5.0.1",
+    "request": "^2.83.0"
+  }
 }

--- a/test/appveyor_install.ps1
+++ b/test/appveyor_install.ps1
@@ -1,7 +1,7 @@
 # Get the latest stable version of Node.js or io.js
 Install-Product node $env:nodejs_version $env:platform
 # if we have defined a specific npm version, use that one
-if ($env:npm_version -ne $null) { npm -i g npm@$env:npm_version }
+if ($env:npm_version -ne $null) { npm i -g npm@$env:npm_version }
 
 node -v
 npm -v

--- a/test/appveyor_install.ps1
+++ b/test/appveyor_install.ps1
@@ -1,0 +1,62 @@
+# Get the latest stable version of Node.js or io.js
+Install-Product node $env:nodejs_version $env:platform
+# if we have defined a specific npm version, use that one
+if ($env:npm_version -ne $null) { npm -i g npm@$env:npm_version }
+
+node -v
+npm -v
+
+$NodeVersion = [System.Version](node -v).Substring(1)
+$NpmVersion = [System.Version](npm -v)
+
+# we force npm to do an actual package install because it will throw a fit otherwise
+# So we capture the current git status in a .tar.gz package
+Push-Location -Path "node_modules\iobroker"
+npm pack | Tee-Object -Variable tgz
+Move-Item -Path $tgz -Destination ..\..
+Pop-Location
+# delete everything else
+Remove-Item "node_modules\iobroker" -Force -Recurse
+
+# try to install ioBroker and capture the response code to test its behavior
+npm install "$tgz" --no-optional
+$EXIT_CODE = $LASTEXITCODE
+
+# node version too old, the script should exit with code 2
+if ($NodeVersion -lt [System.Version]"4.0.0") {
+	if (($EXIT_CODE -eq 2) -or ($EXIT_CODE -eq 1)) {
+		# it should return 2, but apparently, npm@2 just returns 1 on error
+		echo "old node version, correct exit code. stopping installation"
+		# tell the install script that the test was ok but ioB wasn't installed
+		$env:iob_not_installed = "true"
+		exit 0
+	} else {
+		echo "old node version, incorrect exit code $EXIT_CODE. canceling build"
+		exit 1
+	}
+}
+
+# npm version != 5 definitely supported
+if ($NpmVersion.Major -ne 5) {
+	echo "npm version < 5, returning exit code $EXIT_CODE"
+	exit $EXIT_CODE
+}
+
+# npm@5, check the version range
+if (($NpmVersion -ge [System.Version]"5.0.0") -and ($NpmVersion -lt [System.Version]"5.7.1")) {
+	# unsupported version (between 5.0.0 and 5.7.0)
+	# the script should return with exit code 4
+	if ( $EXIT_CODE -eq 4 ) {
+		echo "unsupported npm version $NpmVersion, correct exit code. stopping installation"
+		# tell the install script that the test was ok but ioB wasn't installed
+		$env:iob_not_installed = "true"
+		exit 0
+	} else {
+		echo "unsupported npm version $NpmVersion, incorrect exit code. canceling build"
+		exit 1
+	}
+}
+
+# default: just return the exit code
+echo "installation exit code was $EXIT_CODE"
+exit $EXIT_CODE

--- a/test/travis_install.sh
+++ b/test/travis_install.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+export NPM=$(which npm)
+export NPM_MAJOR=$($NPM -v | cut -d. -f1)
+export NPM_MINOR=$($NPM -v | cut -d. -f2)
+export NPM_BUILD=$($NPM -v | cut -d. -f3)
+export NODE=$(which node)
+export NODE_MAJOR=$($NODE -v | cut -d. -f1 | cut -dv -f2)
+export NODE_MINOR=$($NODE -v | cut -d. -f2)
+export NODE_BUILD=$($NODE -v | cut -d. -f3)
+
+# try to install ioBroker and capture the response code to test its behavior
+sudo env "PATH=$PATH" $NPM install --unsafe-perm; export EXIT_CODE=$?
+# node version too old, the script should exit with code 2
+if [[ $NODE_MAJOR < 4 ]]
+then
+	if [[ $EXIT_CODE -eq 2 ]]; then exit 0 ; else exit 1; fi
+fi
+
+# npm version definitely supported
+if [[ $NPM_MAJOR < 5 || $NPM_MAJOR > 5]]; then exit $EXIT_CODE; fi
+
+# npm@5, check the version range
+if [[ $NPM_MINOR < 7 || ($NPM_MINOR -eq 7 && $NPM_BUILD < 1)]]
+then
+	# unsupported version (between 5.0.0 and 5.7.0)
+	# the script should return with exit code 4
+	if [[ $EXIT_CODE -eq 4 ]]; then exit 0 ; else exit 1; fi
+fi
+
+# default: just return the exit code
+exit $EXIT_CODE

--- a/test/travis_install.sh
+++ b/test/travis_install.sh
@@ -12,20 +12,37 @@ export NODE_BUILD=$($NODE -v | cut -d. -f3)
 # try to install ioBroker and capture the response code to test its behavior
 sudo env "PATH=$PATH" $NPM install --unsafe-perm; export EXIT_CODE=$?
 # node version too old, the script should exit with code 2
-if [[ $NODE_MAJOR < 4 ]]
+if [[ $NODE_MAJOR -lt 4 ]]
 then
-	if [[ $EXIT_CODE -eq 2 ]]; then exit 0 ; else exit 1; fi
+	if [[ $EXIT_CODE -eq 2 ]]
+	then
+		# tell the install script that the test was ok but ioB wasn't installed
+		export IOB_INSTALLED="false"
+		exit 0
+	else
+		exit 1
+	fi
 fi
 
-# npm version definitely supported
-if [[ $NPM_MAJOR < 5 || $NPM_MAJOR > 5]]; then exit $EXIT_CODE; fi
+# npm version != 5 definitely supported
+if [[ $NPM_MAJOR -ne 5 ]]
+then 
+	exit $EXIT_CODE
+fi
 
 # npm@5, check the version range
-if [[ $NPM_MINOR < 7 || ($NPM_MINOR -eq 7 && $NPM_BUILD < 1)]]
+if [[ ($NPM_MINOR -lt 7) || (($NPM_MINOR -eq 7) && ($NPM_BUILD -lt 1)) ]]
 then
 	# unsupported version (between 5.0.0 and 5.7.0)
 	# the script should return with exit code 4
-	if [[ $EXIT_CODE -eq 4 ]]; then exit 0 ; else exit 1; fi
+	if [[ $EXIT_CODE -eq 4 ]]
+	then
+		# tell the install script that the test was ok but ioB wasn't installed
+		export IOB_INSTALLED="false"
+		exit 0
+	else
+		exit 1
+	fi
 fi
 
 # default: just return the exit code

--- a/test/travis_install.sh
+++ b/test/travis_install.sh
@@ -14,8 +14,9 @@ sudo env "PATH=$PATH" $NPM install --unsafe-perm; export EXIT_CODE=$?
 # node version too old, the script should exit with code 2
 if [[ $NODE_MAJOR -lt 4 ]]
 then
-	if [[ $EXIT_CODE -eq 2 ]]
+	if [[ ($EXIT_CODE -eq 2) || ($EXIT_CODE -eq 1) ]]
 	then
+		# it should return 2, but apparently, npm@2 just returns 1 on error
 		echo "old node version, correct exit code. stopping installation"
 		# tell the install script that the test was ok but ioB wasn't installed
 		touch iob_not_installed

--- a/test/travis_install.sh
+++ b/test/travis_install.sh
@@ -10,7 +10,7 @@ export NODE_MINOR=$($NODE -v | cut -d. -f2)
 export NODE_BUILD=$($NODE -v | cut -d. -f3)
 
 # try to install ioBroker and capture the response code to test its behavior
-sudo env "PATH=$PATH" $NPM install --unsafe-perm; export EXIT_CODE=$?
+sudo env "PATH=$PATH" $NPM install --unsafe-perm --prefix "node_modules/iobroker"; export EXIT_CODE=$?
 # node version too old, the script should exit with code 2
 if [[ $NODE_MAJOR -lt 4 ]]
 then

--- a/test/travis_install.sh
+++ b/test/travis_install.sh
@@ -16,10 +16,12 @@ if [[ $NODE_MAJOR -lt 4 ]]
 then
 	if [[ $EXIT_CODE -eq 2 ]]
 	then
+		echo "old node version, correct exit code. stopping installation"
 		# tell the install script that the test was ok but ioB wasn't installed
 		export IOB_INSTALLED="false"
 		exit 0
 	else
+		echo "old node version, incorrect exit code. canceling build"
 		exit 1
 	fi
 fi
@@ -27,6 +29,7 @@ fi
 # npm version != 5 definitely supported
 if [[ $NPM_MAJOR -ne 5 ]]
 then 
+	echo "npm version < 5, returning exit code $EXIT_CODE"
 	exit $EXIT_CODE
 fi
 
@@ -37,13 +40,16 @@ then
 	# the script should return with exit code 4
 	if [[ $EXIT_CODE -eq 4 ]]
 	then
+		echo "unsupported npm version $NPM_MAJOR.$NPM_MINOR.$NPM_BUILD, correct exit code. stopping installation"
 		# tell the install script that the test was ok but ioB wasn't installed
 		export IOB_INSTALLED="false"
 		exit 0
 	else
+		echo "unsupported npm version $NPM_MAJOR.$NPM_MINOR.$NPM_BUILD, incorrect exit code. canceling build"
 		exit 1
 	fi
 fi
 
 # default: just return the exit code
+echo "installation exit code was $EXIT_CODE"
 exit $EXIT_CODE

--- a/test/travis_install.sh
+++ b/test/travis_install.sh
@@ -30,7 +30,7 @@ fi
 # npm version != 5 definitely supported
 if [[ $NPM_MAJOR -ne 5 ]]
 then 
-	echo "npm version < 5, returning exit code $EXIT_CODE"
+	echo "npm version != 5.x, returning exit code $EXIT_CODE"
 	exit $EXIT_CODE
 fi
 

--- a/test/travis_install.sh
+++ b/test/travis_install.sh
@@ -18,10 +18,10 @@ then
 	then
 		echo "old node version, correct exit code. stopping installation"
 		# tell the install script that the test was ok but ioB wasn't installed
-		export IOB_INSTALLED="false"
+		touch iob_not_installed
 		exit 0
 	else
-		echo "old node version, incorrect exit code. canceling build"
+		echo "old node version, incorrect exit code $EXIT_CODE. canceling build"
 		exit 1
 	fi
 fi
@@ -42,7 +42,7 @@ then
 	then
 		echo "unsupported npm version $NPM_MAJOR.$NPM_MINOR.$NPM_BUILD, correct exit code. stopping installation"
 		# tell the install script that the test was ok but ioB wasn't installed
-		export IOB_INSTALLED="false"
+		touch iob_not_installed
 		exit 0
 	else
 		echo "unsupported npm version $NPM_MAJOR.$NPM_MINOR.$NPM_BUILD, incorrect exit code. canceling build"

--- a/test/travis_prepareTest.sh
+++ b/test/travis_prepareTest.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+cd ../..
+sudo chmod -R 777 *
+ps auxww|grep io
+./iobroker start
+cd node_modules/iobroker/
+npm install request
+npm install mocha
+npm install chai
+sleep 60
+ps auxww|grep io
+date
+cat ../../log/iobroker*.log

--- a/test/travis_prepareTest.sh
+++ b/test/travis_prepareTest.sh
@@ -1,14 +1,13 @@
 #!/bin/bash
 
 cd ../..
+
 sudo chmod -R 777 *
 ps auxww|grep io
 ./iobroker start
-cd node_modules/iobroker/
-npm install request
-npm install mocha
-npm install chai
 sleep 60
 ps auxww|grep io
 date
 cat ../../log/iobroker*.log
+
+cd node_modules/iobroker/

--- a/test/travis_prepareTest.sh
+++ b/test/travis_prepareTest.sh
@@ -1,13 +1,12 @@
 #!/bin/bash
 
-cd ../..
-
 sudo chmod -R 777 *
 ps auxww|grep io
 ./iobroker start
+
+npm install request mocha chai --save
+
 sleep 60
 ps auxww|grep io
 date
-cat ../../log/iobroker*.log
-
-cd node_modules/iobroker/
+cat log/iobroker*.log


### PR DESCRIPTION
This PR adds support for npm@5, starting with version 5.7.1.

The main change is in lib/prepareSetup.js#L62. By creating a `.npmrc` file with contents `package-lock=false` we force npm to ignore the `package-lock.json` which is the main cause for all our troubles on npm@5.
The file is still being created and still misses some of the ioBroker packages (don't ask me why) but now it doesn't fuck with our installation.

Two small improvements to the install script:
* the generated `package.json` does not need to include the dependencies as we're going to install them with `--save` directly afterwards.
* also we don't need to overwrite the `package.json` to add the actual versions, npm does that already.

From my side, this is now ready for merging. However it **must** be merged and published together with https://github.com/ioBroker/ioBroker.js-controller/pull/171