### PR TITLE
Remove the dist-tag from the package name for install check

### DIFF
--- a/lib/setup.js
+++ b/lib/setup.js
@@ -402,8 +402,14 @@ function npmInstall(packet, isSudo, callback) {
     child.on('exit', function () {
         var packetFolder = packet.toLowerCase();
         // clean up packet directory
+        // extract the packet name from a github url
         if (packetFolder.indexOf("github.com") > -1) {
             packetFolder = /github\.com\/\w+\/([^\/]+)\//.exec(packetFolder)[1]
+        }
+        // remove dist-tag
+        // scoped packages start with @, so we have to check if @ is in a later position
+        if (packetFolder.indexOf("@") > 0) {
+            packetFolder = packetFolder.substr(0, packetFolder.indexOf("@"));
         }
         packetFolder = path.join(rootDir, '/node_modules/', packetFolder);
         console.log("packet folder is: " + packetFolder + " | exists: " + fs.existsSync(packetFolder));


### PR DESCRIPTION
Since commit d908fe8 we install the main packages with the `stable` dist tag but the function `npmInstall` uses the given package name to check if the installation was successful. Like with github urls, we need to strip the dist-tag from the folder name we're using to check the installation.