### PR TITLE
Don't require iobroker package during installation

### DIFF
--- a/lib/setup.js
+++ b/lib/setup.js
@@ -442,7 +442,6 @@ function setup(callback) {
             private: true,
             description: 'Automation platform in node.js',
             dependencies: {
-                iobroker: ownVersion
             }
         }, null, 2));
     }


### PR DESCRIPTION
Stops npm 5.7.1 from complaining that no matching version for iobroker was found.