### PR TITLE
Fix proposed command to update to a supported npm5-version

### DIFF
--- a/lib/prepareSetup.js
+++ b/lib/prepareSetup.js
@@ -16,7 +16,7 @@ function checkNpmVersion() {
             if (npmVersion) npmVersion = semver.valid(npmVersion.trim());
             console.log('NPM version: ' + npmVersion);
         } catch (e) {
-            console.error('Error trying to check npm version: ' + errResp);
+            console.error('Error trying to check npm version: ' + e);
         }
 
         if (nodeVersion && semver.lt(nodeVersion, "4.0.0")) {

--- a/lib/prepareSetup.js
+++ b/lib/prepareSetup.js
@@ -32,8 +32,8 @@ function checkNpmVersion() {
             console.error('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!');
             console.error('Aborting install because the npm version could not be checked!');
             console.error('Please check that npm is installed correctly.');
-            console.error('Use "npm install -g npm@4" or "npm install -g npm@>=5.7.1" to install a supported version.');
-            console.error('You need to make sure to repeat this step after installing an update to NodeJS and/or npm');
+            console.error('Use "npm install -g npm@4" or "npm install -g npm@latest" to install a supported version.');
+            console.error('You need to make sure to repeat this step after installing an update to NodeJS and/or npm.');
             console.error('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!');
             process.exit(3);
             return;
@@ -43,9 +43,8 @@ function checkNpmVersion() {
             console.error('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!');
             console.error('NPM 5 is only supported starting with version 5.7.1!');
             console.error('Please use "npm install -g npm@4" to downgrade npm to 4.x or ');
-            console.error('use "npm install -g npm@>=5.7.1" to install a supported version of npm 5!')
-            console.error('You need to make sure to downgrade again with the above command after you');
-            console.error('You need to make sure to repeat this step after installing an update to NodeJS and/or npm');
+            console.error('use "npm install -g npm@latest" to install a supported version of npm 5!')
+            console.error('You need to make sure to repeat this step after installing an update to NodeJS and/or npm.');
             console.error('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!');
             process.exit(4);
             return;


### PR DESCRIPTION
`@latest` is `now >= 5.7.1`, this makes it easier.
The old command needed quotes around "npm@>=5.7.1". Forgetting the quotes would only create a logfile (name `=5.7.1`) of the installation of the latest version at that time.