### PR TITLE
Reworked npm adapter version check

### DIFF
--- a/lib/prepareSetup.js
+++ b/lib/prepareSetup.js
@@ -12,7 +12,20 @@ function checkNpmVersion() {
         var nodeVersion = semver.valid(process.version);
         var npmVersion;
         try {
-            npmVersion = child_process.execSync('npm -v', { encoding: "utf8" });
+            // remove local node_modules\.bin dir from path
+            // or we potentially get a wrong npm version
+            var newEnv = Object.assign({}, process.env);
+            newEnv.PATH = (newEnv.PATH || newEnv.Path || newEnv.path)
+                .split(path.delimiter)
+                .filter(dir => {
+                    dir = dir.toLowerCase();
+                    if (dir.indexOf("iobroker") > -1 && dir.indexOf(path.join("node_modules", ".bin")) > -1) return false;
+                    return true;
+                })
+                .join(path.delimiter)
+                ;
+
+            npmVersion = child_process.execSync('npm -v', { encoding: "utf8", env: newEnv });
             if (npmVersion) npmVersion = semver.valid(npmVersion.trim());
             console.log('NPM version: ' + npmVersion);
         } catch (e) {
@@ -50,8 +63,7 @@ function checkNpmVersion() {
             return;
         }
         return npmVersion;
-    }
-    catch (e) {
+    } catch (e) {
         console.error('Could not check npm version: ' + e);
         console.error('Assuming that correct version is installed.');
     }

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -1,4 +1,5 @@
 var fs = require('fs');
+var semver = require('semver');
 var request;
 var extend;
 
@@ -268,53 +269,32 @@ function getInstalledInfo(hostRunningVersion) {
     return result;
 }
 
-function initNpm(prefix, callback) {
-    if (typeof prefix === 'function') {
-        callback = prefix;
-        prefix = undefined;
-    }
 
-    var settings = {
-        silent: true,
-        global: false,
-        production: true,
-        minTimeout: 500,
-        maxTimeout: 1500,
-        times: 1
-    };
-    if (prefix) settings.prefix = prefix;
-
-    var npm = require('npm');
-    npm.load(settings, function (er) {
-        // Disable debug outputs
-        npm.registry.log.silly   = function () {};
-        npm.registry.log.verbose = function () {};
-        npm.registry.log.info    = function () {};
-        npm.registry.log.http    = function () {};
-        if (callback) callback(er, npm);
-    });
-}
-
-// reads version of packet from npm
+/**
+ * Reads an adapter's npm version
+ * @param {string | null} adapter The adapter to read the npm version from. Null for the root ioBroker packet
+ * @param {(err: Error | null, version: string) => void} [callback]
+ */
 function getNpmVersion(adapter, callback) {
     adapter = adapter ? 'iobroker.' + adapter : 'iobroker';
+    adapter = adapter.toLowerCase();
 
-    try {
-        initNpm(function (er, npm) {
-            npm.commands.view([adapter, 'dist-tags.latest'], true, function (error, response) {
-                if (error) return callback ? callback(error) : 0;
+    const cliCommand = `npm view ${adapter}@latest version`;
 
-                if (response) {
-                    if (callback) callback(error, Object.keys(response)[0]);
-                } else {
-                    if (callback) callback(error);
-                }
-            });
-        });
-    } catch (e) {
-        console.log('error by reading ' + adapter + ': ' + e);
-        if (callback) callback(e);
-    }
+    var exec = require('child_process').exec;
+    exec(cliCommand, {timeout: 2000}, (error, stdout, stderr) => {
+        let version;
+        if (error) {
+            // command failed
+            if (typeof callback === "function") {
+                callback(error);
+                return;
+            }
+        } else if (stdout) {
+            version = semver.valid(stdout.trim());
+        }
+        if (typeof callback === "function") callback(null, version);
+    });
 }
 
 function getIoPack(sources, name, callback) {
@@ -565,4 +545,3 @@ module.exports.sendDiagInfo =          sendDiagInfo;
 module.exports.getAdapterDir =         getAdapterDir;
 module.exports.getDefaultDataDir =     getDefaultDataDir;
 module.exports.getConfigFileName =     getConfigFileName;
-module.exports.initNpm =               initNpm;


### PR DESCRIPTION
to work without js-controller's outdated `npm` package

Followup to:
https://github.com/ioBroker/ioBroker.js-controller/pull/174