### PR TITLE
Use unsafe-perm for the actual installation

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -16,7 +16,7 @@ if (tools.isThisInsideNodeModules()) {
 │ The iobroker files have been downloaded successfully. │
 │ To complete the installation, you need to run         │
 │                                                       │
-│                  npm i --production                   │
+│           npm i --production --unsafe-perm            │
 │                                                       │
 ╰───────────────────────────────────────────────────────╯
 `));


### PR DESCRIPTION
So users do the same as the automated installer.

TODO: release this as 1.3.1