### PR TITLE
Next attempt at fixing permission problems in `/opt/iobroker`

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -117,7 +117,7 @@ if [ -f /lib/systemd/system/iobroker.service ]; then
 		# To allow the current user to install adapters via the shell,
 		# We need to give it access rights to the directory aswell
 		sudo usermod -a -G iobroker $USER
-		sudo chmod g+w /opt/iobroker
+		sudo chmod -R g+w /opt/iobroker
 	fi
 
 	if [ "$IS_ROOT" = true ]; then

--- a/installer.sh
+++ b/installer.sh
@@ -2,22 +2,22 @@
 
 # Enable colored output
 if test -t 1; then # if terminal
-    ncolors=$(which tput > /dev/null && tput colors) # supports color
-    if test -n "$ncolors" && test $ncolors -ge 8; then
-        termcols=$(tput cols)
-        bold="$(tput bold)"
-        underline="$(tput smul)"
-        standout="$(tput smso)"
-        normal="$(tput sgr0)"
-        black="$(tput setaf 0)"
-        red="$(tput setaf 1)"
-        green="$(tput setaf 2)"
-        yellow="$(tput setaf 3)"
-        blue="$(tput setaf 4)"
-        magenta="$(tput setaf 5)"
-        cyan="$(tput setaf 6)"
-        white="$(tput setaf 7)"
-    fi
+	ncolors=$(which tput > /dev/null && tput colors) # supports color
+	if test -n "$ncolors" && test $ncolors -ge 8; then
+		termcols=$(tput cols)
+		bold="$(tput bold)"
+		underline="$(tput smul)"
+		standout="$(tput smso)"
+		normal="$(tput sgr0)"
+		black="$(tput setaf 0)"
+		red="$(tput setaf 1)"
+		green="$(tput setaf 2)"
+		yellow="$(tput setaf 3)"
+		blue="$(tput setaf 4)"
+		magenta="$(tput setaf 5)"
+		cyan="$(tput setaf 6)"
+		white="$(tput setaf 7)"
+	fi
 fi
 
 HLINE="=========================================================================="
@@ -63,9 +63,21 @@ fi
 
 print_bold "Welcome to the ioBroker installer!" "You might need to enter your password a couple of times."
 
-NUM_STEPS=4
+NUM_STEPS=5
 
-print_step "Creating ioBroker directory" 1 "$NUM_STEPS"
+print_step "Installing prerequisites" 1 "$NUM_STEPS"
+# Test if acl is installed, so we can use setfacl
+dpkg -s acl &> /dev/null
+if [ $? -ne 0 ]; then
+	# Install acl, so we can use setfacl
+	if [ "$IS_ROOT" = true ]; then
+		apt install -y acl
+	else
+		sudo apt install -y acl
+	fi
+fi
+
+print_step "Creating ioBroker directory" 2 "$NUM_STEPS"
 # ensure the directory exists and take control of it
 if [ "$IS_ROOT" = true ]; then
 	mkdir -p /opt/iobroker
@@ -78,7 +90,7 @@ cd /opt/iobroker
 # suppress messages with manual installation steps
 touch AUTOMATED_INSTALLER
 
-print_step "Downloading installation files" 2 "$NUM_STEPS"
+print_step "Downloading installation files" 3 "$NUM_STEPS"
 
 # download the installer files and run them
 # If this script is run as root, we need the --unsafe-perm option
@@ -88,7 +100,7 @@ else
 	npm i iobroker --loglevel error
 fi
 
-print_step "Installing ioBroker" 3 "$NUM_STEPS"
+print_step "Installing ioBroker" 4 "$NUM_STEPS"
 
 # TODO: GH#48 Make sure we don't need sudo/root, so we can remove that and --unsafe-perm
 # For now we need to run the 2nd part of the installation as root
@@ -99,27 +111,35 @@ else
 fi
 # npm i --production # this is how it should be
 
-print_step "Finalizing installation" 4 "$NUM_STEPS"
+print_step "Finalizing installation" 5 "$NUM_STEPS"
 
 # Remove the file we used to suppress messages during installation
 rm AUTOMATED_INSTALLER
 
 # If we want to autostart ioBroker with systemd, enable that
 if [ -f /lib/systemd/system/iobroker.service ]; then
-	echo "Enabling autostart..."
-
 	# systemd executes js-controller as the user "iobroker", 
 	# so we need to give it the ownershop of /opt/iobroker
+	echo "Fixing directory permissions..."
 	if [ "$IS_ROOT" = true ]; then
 		chown iobroker:iobroker -R /opt/iobroker
+		# No need to give special permissions, root has access anyways
 	else
 		sudo chown iobroker:iobroker -R /opt/iobroker
 		# To allow the current user to install adapters via the shell,
 		# We need to give it access rights to the directory aswell
 		sudo usermod -a -G iobroker $USER
-		sudo chmod -R g+w /opt/iobroker
+		# Give the iobroker group write access to all files by setting the default ACL
+		sudo setfacl -Rdm g:iobroker:rwx /opt/iobroker &> /dev/null && sudo setfacl -Rm g:iobroker:rwx /opt/iobroker &> /dev/null
+		if [ $? -ne 0 ]; then
+			# We cannot rely on default permissions on this system
+			echo "${yellow}This system does not support setting default permissions."
+			echo "${yellow}Do not use npm to manually install adapters unless you know what you are doing!"
+			touch DO_NOT_USE_NPM_MANUALLY
+		fi
 	fi
 
+	echo "Enabling autostart..."
 	if [ "$IS_ROOT" = true ]; then
 		systemctl daemon-reload
 		systemctl enable iobroker

--- a/installer.sh
+++ b/installer.sh
@@ -158,3 +158,5 @@ else
 fi
 
 print_bold "${green}ioBroker was installed successfully${normal}" "Open http://localhost:8081 in a browser and start configuring!"
+
+print_msg "${yellow}You need to re-login before doing anything else on the console!"

--- a/installer.sh
+++ b/installer.sh
@@ -71,7 +71,7 @@ if [ "$IS_ROOT" = true ]; then
 	mkdir -p /opt/iobroker
 else
 	sudo mkdir -p /opt/iobroker
-	sudo chown $USER -R /opt/iobroker
+	sudo chown $USER:$USER -R /opt/iobroker
 fi
 cd /opt/iobroker
 
@@ -101,6 +101,9 @@ fi
 
 print_step "Finalizing installation" 4 "$NUM_STEPS"
 
+# Remove the file we used to suppress messages during installation
+rm AUTOMATED_INSTALLER
+
 # If we want to autostart ioBroker with systemd, enable that
 if [ -f /lib/systemd/system/iobroker.service ]; then
 	echo "Enabling autostart..."
@@ -108,12 +111,13 @@ if [ -f /lib/systemd/system/iobroker.service ]; then
 	# systemd executes js-controller as the user "iobroker", 
 	# so we need to give it the ownershop of /opt/iobroker
 	if [ "$IS_ROOT" = true ]; then
-		chown iobroker -R /opt/iobroker
+		chown iobroker:iobroker -R /opt/iobroker
 	else
-		sudo chown iobroker -R /opt/iobroker
+		sudo chown iobroker:iobroker -R /opt/iobroker
 		# To allow the current user to install adapters via the shell,
 		# We need to give it access rights to the directory aswell
-		sudo useradd -G iobroker $USER
+		sudo usermod -a -G iobroker $USER
+		sudo chmod g+w /opt/iobroker
 	fi
 
 	if [ "$IS_ROOT" = true ]; then
@@ -130,10 +134,7 @@ else
 	# After sudo npm i, this directory now belongs to root. 
 	# Give it back to the current user
 	# TODO: remove this step when GH#48 is resolved
-	sudo chown $USER -R /opt/iobroker
+	sudo chown $USER:$USER -R /opt/iobroker
 fi
-
-# Remove the file we used to suppress messages during installation
-rm AUTOMATED_INSTALLER
 
 print_bold "${green}ioBroker was installed successfully${normal}" "Open http://localhost:8081 in a browser and start configuring!"


### PR DESCRIPTION
Specifically:
* The AUTOMATED_INSTALLER file is deleted before changing permissions
* The owner group of the directory is also set to iobroker
* The user who started the installation is added to the owner group