### PR TITLE
IOBroker can now use node installed with nvm

### DIFF
--- a/install/linux/install.sh
+++ b/install/linux/install.sh
@@ -53,7 +53,7 @@ chmod 755 /usr/bin/iob
 #Replace user pi with current user
 sed -i -e "s/IOBROKERUSER=.*/IOBROKERUSER=$IO_USER/" /etc/init.d/iobroker.sh
 NODE=${NODE//\//\\/}
-sed -i -e s/NODECMD=.*/NODECMD=$NODE/ /etc/init.d/iobroker.sh
+sed -i -e s/NODECMD=@@.*/NODECMD=$NODE/ /etc/init.d/iobroker.sh
 chown root:root /etc/init.d/iobroker.sh
 update-rc.d iobroker.sh defaults
 

--- a/install/linux/iobroker.sh
+++ b/install/linux/iobroker.sh
@@ -10,10 +10,20 @@
 ### END INIT INFO
 (( EUID )) && echo .You need to have root privileges.. && exit 1
 PIDF=@@PATH@@lib/iobroker.pid
-NODECMD=@@node
 IOBROKERCMD=@@PATH@@iobroker.js
 RETVAL=0
 IOBROKERUSER=@@user
+HOMEDIR=`getent passwd ${IOBROKERUSER} | cut -d\: -f 6`
+NVM_DIR="${HOMEDIR}/.nvm"
+if [ -d "${NVM_DIR}" ]; then
+            export NVM_DIR
+            [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
+            NODECMD=`nvm which node`
+            echo "NVM detected."
+            echo "Use ${NODECMD} to start IOBroker."
+else
+            NODECMD=@@node
+fi
 
 start() {
             export IOBROKER_HOME=@@HOME@@

--- a/lib/installSetup.js
+++ b/lib/installSetup.js
@@ -20,6 +20,7 @@ const yargs = require('yargs')
 
 const fs = require('fs-extra');
 const path = require('path');
+const which = require('which');
 const child_process = require('child_process');
 const exec = child_process.exec;
 const tools = require('./tools.js');
@@ -196,6 +197,7 @@ function setupFreeBSD(callback) {
 }
 
 function getNode() {
+    var nodeExecutable = which.sync('node', { nothrow: true });
     if (fs.existsSync('/usr/bin/node')) {
         return '/usr/bin/node';
     } else if (fs.existsSync('/usr/bin/nodejs')) {
@@ -204,6 +206,10 @@ function getNode() {
         return '/usr/sbin/nodejs';
     } else if (fs.existsSync('/usr/sbin/node')) {
         return '/usr/sbin/node';
+    } else if (fs.existsSync('/usr/local/bin/node')) {
+	return '/usr/local/bin/node';
+    } else if (nodeExecutable) {
+        return nodeExecutable;
     } else {
         return '/usr/bin/node';
     }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "colors": "^1.3.2",
     "fs-extra": "^7.0.0",
     "semver": "^5.5.0",
+    "which": "^1.3.1",
     "yargs": "^7.0.2"
   },
   "homepage": "http://iobroker.net",


### PR DESCRIPTION
Currently iobroker relies on a fixed node version installed on a fixed path.
This patch enables the startup script to work also with node installed by nvm.