### PR TITLE
[WIP] Move linux installation completely into the installer script

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -197,8 +197,8 @@ fix_dir_permissions() {
 		sudo setfacl -Rdm g:iobroker:rwx /opt/iobroker &> /dev/null && sudo setfacl -Rm g:iobroker:rwx /opt/iobroker &> /dev/null
 		if [ $? -ne 0 ]; then
 			# We cannot rely on default permissions on this system
-			echo "${yellow}This system does not support setting default permissions."
-			echo "${yellow}Do not use npm to manually install adapters unless you know what you are doing!"
+			echo "${yellow}This system does not support setting default permissions.${normal}"
+			echo "${yellow}Do not use npm to manually install adapters unless you know what you are doing!${normal}"
 			echo "ACL enabled: false" >> INSTALLER_INFO.txt
 		fi
 	fi
@@ -241,7 +241,7 @@ elif [ "$INITSYSTEM" = "init.d"]; then
 	# TODO
 	echo "Autostart: init.d" >> INSTALLER_INFO.txt
 else
-	echo "Unsupported init system, cannot enable autostart"
+	echo "${yellow}Unsupported init system, cannot enable autostart!${normal}"
 	echo "Autostart: false" >> INSTALLER_INFO.txt
 	# After sudo npm i, this directory now belongs to root. 
 	# Give it back to the current user
@@ -252,4 +252,4 @@ fi
 IP=$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)
 print_bold "${green}ioBroker was installed successfully${normal}" "Open http://$IP:8081 in a browser and start configuring!"
 
-print_msg "${yellow}You need to re-login before doing anything else on the console!"
+print_msg "${yellow}You need to re-login before doing anything else on the console!${normal}"

--- a/installer.sh
+++ b/installer.sh
@@ -111,6 +111,15 @@ NUM_STEPS=5
 print_step "Installing prerequisites" 1 "$NUM_STEPS"
 install_package "acl"  # To use setfacl
 install_package "sudo" # To use sudo (obviously)
+# These are used by a couple of adapters and should therefore exist:
+install_package "build-essential"
+install_package "libavahi-compat-libdnssd-dev"
+install_package "libudev-dev"
+install_package "libpam0g-dev"
+install_package "pkg-config"
+install_package "git"
+install_package "curl"
+install_package "unzip"
 # TODO: Which other packages do we need by default?
 
 print_step "Creating ioBroker directory" 2 "$NUM_STEPS"
@@ -149,9 +158,9 @@ print_step "Installing ioBroker" 4 "$NUM_STEPS"
 # TODO: GH#48 Make sure we don't need sudo/root, so we can remove that and --unsafe-perm
 # For now we need to run the 2nd part of the installation as root
 if [ "$IS_ROOT" = true ]; then
-	npm i --production --unsafe-perm
+	npm i --production --loglevel error --unsafe-perm
 else
-	sudo -H npm i --production --unsafe-perm
+	sudo -H npm i --production --loglevel error --unsafe-perm
 fi
 # npm i --production # this is how it should be
 

--- a/lib/installSetup.js
+++ b/lib/installSetup.js
@@ -226,27 +226,8 @@ function checkUserLinux() {
 }
 
 function createUserLinux(callback) {
-    if (checkUserLinux()) {
-        log('User iobroker exists');
-        return callback && callback();
-    } else if (isRoot()) {
-        log('Create user iobroker');
-
-        exec('useradd -m -s /usr/sbin/nologin iobroker', err => {
-            // add to serial
-            exec('usermod -a -G dialout iobroker', () => {
-                exec('usermod -a -G tty iobroker', () => {
-                    // Add to GPIO group
-                    exec('usermod -a -G gpio iobroker', () => {
-                        callback(err);
-                    });
-                });
-            });
-        });
-    } else {
-        log('Required root rights to create user');
-        callback('Not root');
-    }
+    callback();
+    // This method has been moved to the shell script
 }
 
 function chownLinux(user, callback) {


### PR DESCRIPTION
This contains a bunch of changes and is not done yet. I'm opening this PR to get early feedback.

Mainly, the entire installation code will be moved into the installer shell script to have it in one place and not 3 or 4.

Still missing:
- [ ] Automatic creation of `init.d` script if that is used
- [ ] Creation of `iob` and `iobroker` binaries
- [ ] Cleanup in `installSetup.js` and the `install/linux` folder