### PR TITLE
Fix `iobroker {start,stop,restart} adaptername` when using `systemd`

### DIFF
--- a/CHANGELOG_INSTALLER_LINUX.md
+++ b/CHANGELOG_INSTALLER_LINUX.md
@@ -1,5 +1,9 @@
 # Changelog for Linux-Installer-Script
 
+## 2019-01-23
+* Revert the `KillMode` change
+* Redirect `iobroker {start,stop,restart} adaptername` to `node` when using `systemd`
+
 ## 2019-01-22
 * Use `KillMode=process` in `systemd` to prevent detached processes from being killed aswell
 

--- a/CHANGELOG_INSTALLER_LINUX.md
+++ b/CHANGELOG_INSTALLER_LINUX.md
@@ -2,7 +2,21 @@
 
 ## 2019-01-23
 * Revert the `KillMode` change
-* Redirect `iobroker {start,stop,restart} adaptername` to `node` when using `systemd`
+* Redirect `iobroker {start,stop,restart} adaptername` to `node` when using `systemd`.  
+**Note:** If you cannot start/stop adapters using the command line, you have to edit the iobroker binary:
+  ```
+  sudo nano $(which iob)
+  ```
+  and change
+  ```
+  if [ "$1" = "start" ] || [ "$1" = "stop" ] || [ "$1" = "restart" ]; then
+  ```
+  to
+  ```
+  if (( $# == 1 )) && ([ "$1" = "start" ] || [ "$1" = "stop" ] || [ "$1" = "restart" ]); then
+  ```
+  Then exit and save.
+
 
 ## 2019-01-22
 * Use `KillMode=process` in `systemd` to prevent detached processes from being killed aswell

--- a/installer.sh
+++ b/installer.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Increase this version number whenever you update the installer
-INSTALLER_VERSION="2019-01-22" # format YYYY-MM-DD
+INSTALLER_VERSION="2019-01-23" # format YYYY-MM-DD
 
 # Test if this script is being run as root or not
 # TODO: To resolve #48, running this as root should be prohibited
@@ -370,9 +370,10 @@ if [ "$IOB_USER" != "$USER" ]; then
 fi
 if [ "$INITSYSTEM" = "systemd" ]; then
 	# systemd needs a special executable that reroutes iobroker start/stop to systemctl
+	# Make sure to only use systemd when there is exactly 1 argument
 	IOB_EXECUTABLE=$(cat <<- EOF
 		#!/bin/bash
-		if [ "\$1" = "start" ] || [ "\$1" = "stop" ] || [ "\$1" = "restart" ]; then
+		if (( \$# == 1 )) && ([ "\$1" = "start" ] || [ "\$1" = "stop" ] || [ "\$1" = "restart" ]); then
 			sudo systemctl \$1 iobroker
 		else
 			$IOB_NODE_CMDLINE $CONTROLLER_DIR/iobroker.js \$1 \$2 \$3 \$4 \$5


### PR DESCRIPTION
and update changelog.

This was broken with 2.0, we forgot to fix it.