### PR TITLE
Give nodejs access to protected ports

### DIFF
--- a/CHANGELOG_INSTALLER_LINUX.md
+++ b/CHANGELOG_INSTALLER_LINUX.md
@@ -1,7 +1,9 @@
 # Changelog for Linux-Installer-Script
 
-## 2019-01-25
+## 2019-01-30
+* Give NodeJS access to privileged ports (<1024 and Bluetooth)
 
+## 2019-01-25
 * (FreeBSD) Added added a procedure to handle the freebsd package installation (there is no apt on BSD). `install_package_freebsd()`
 * (FreeBSD) Added a rough list of packages for iobroker to run on FreeBSD (subject to further improvement).
 * (FreeBSD) Added config patches for the zero conf daemon processes, add them to rc startup and start them.

--- a/installer.sh
+++ b/installer.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Increase this version number whenever you update the installer
-INSTALLER_VERSION="2019-01-25" # format YYYY-MM-DD
+INSTALLER_VERSION="2019-01-30" # format YYYY-MM-DD
 
 # Test if this script is being run as root or not
 # TODO: To resolve #48, running this as root should be prohibited
@@ -297,6 +297,7 @@ case "$platform" in
 		declare -a packages=(
 			"acl" # To use setfacl
 			"sudo" # To use sudo (obviously)
+			"libcap2-bin" # To give nodejs access to protected ports
 			# These are used by a couple of adapters and should therefore exist:
 			"build-essential"
 			"libavahi-compat-libdnssd-dev"
@@ -310,6 +311,12 @@ case "$platform" in
 		for pkg in "${packages[@]}"; do
 			install_package_linux $pkg
 		done
+
+		# ==================
+		# Configure packages
+
+		# Give nodejs access to protected ports
+		sudo setcap cap_net_bind_service=+eip $(eval readlink -f `which node`)
 		;;
 	"freebsd")
 		declare -a packages=(


### PR DESCRIPTION
As described here: https://forum.iobroker.net/viewtopic.php?p=225774#p225774
This is required for BLE and some adapters that need to access ports < 1024

FreeBSD seems more complicated, because you have to give a specific user access to specific ports. So for now this is limited to Linux