### PR TITLE
Add redis as a dependency to the systemd unit and init.d script

### DIFF
--- a/CHANGELOG_FIXER_LINUX.md
+++ b/CHANGELOG_FIXER_LINUX.md
@@ -1,7 +1,7 @@
 # Changelog for Linux-Fixer-Script
 
-## 2019-02-27
-* Add redis as a dependency to the systemd unit to avoid deadlocks on shutdown
+## 2019-03-01
+* Add redis as a dependency to the `systemd` unit and `init.d` script to avoid deadlocks on shutdown
 
 ## 2019-02-25
 * Fix setcap and include all in one command

--- a/CHANGELOG_FIXER_LINUX.md
+++ b/CHANGELOG_FIXER_LINUX.md
@@ -1,7 +1,10 @@
 # Changelog for Linux-Fixer-Script
 
+## 2019-02-27
+* Add redis as a dependency to the systemd unit to avoid deadlocks on shutdown
+
 ## 2019-02-25
-* fix setcap and include all in one command
+* Fix setcap and include all in one command
 
 ## 2019-02-23
 * Give nodejs access to raw devices like ble

--- a/CHANGELOG_INSTALLER_LINUX.md
+++ b/CHANGELOG_INSTALLER_LINUX.md
@@ -1,5 +1,8 @@
 # Changelog for Linux-Installer-Script
 
+## 2019-02-27
+* Add redis as a dependency to the systemd unit to avoid deadlocks on shutdown
+
 ## 2019-02-25
 * fix setcap and include all in one command
 

--- a/CHANGELOG_INSTALLER_LINUX.md
+++ b/CHANGELOG_INSTALLER_LINUX.md
@@ -1,7 +1,7 @@
 # Changelog for Linux-Installer-Script
 
-## 2019-02-27
-* Add redis as a dependency to the systemd unit to avoid deadlocks on shutdown
+## 2019-03-01
+* Add redis as a dependency to the `systemd` unit and `init.d` script to avoid deadlocks on shutdown
 
 ## 2019-02-25
 * fix setcap and include all in one command

--- a/fix_installation.sh
+++ b/fix_installation.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Increase this version number whenever you update the fixer
-FIXER_VERSION="2019-02-25" # format YYYY-MM-DD
+FIXER_VERSION="2019-02-27" # format YYYY-MM-DD
 
 # Test if this script is being run as root or not
 if [[ $EUID -eq 0 ]]; then
@@ -692,7 +692,8 @@ elif [ "$INITSYSTEM" = "systemd" ]; then
 		[Unit]
 		Description=ioBroker Server
 		Documentation=http://iobroker.net
-		After=network.target
+		After=network.target redis.service
+		Wants=redis.service
 		
 		[Service]
 		Type=simple

--- a/fix_installation.sh
+++ b/fix_installation.sh
@@ -634,7 +634,9 @@ if [[ "$INITSYSTEM" = "init.d" ]]; then
 		### BEGIN INIT INFO
 		# Provides:          iobroker.sh
 		# Required-Start:    \$network \$local_fs \$remote_fs
-		# Required-Stop::    \$network \$local_fs \$remote_fs
+		# Required-Stop:     \$network \$local_fs \$remote_fs
+		# Should-Start:      redis-server
+		# Should-Stop:       redis-server
 		# Default-Start:     2 3 4 5
 		# Default-Stop:      0 1 6
 		# Short-Description: starts ioBroker

--- a/fix_installation.sh
+++ b/fix_installation.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Increase this version number whenever you update the fixer
-FIXER_VERSION="2019-02-27" # format YYYY-MM-DD
+FIXER_VERSION="2019-03-01" # format YYYY-MM-DD
 
 # Test if this script is being run as root or not
 if [[ $EUID -eq 0 ]]; then

--- a/installer.sh
+++ b/installer.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Increase this version number whenever you update the installer
-INSTALLER_VERSION="2019-02-27" # format YYYY-MM-DD
+INSTALLER_VERSION="2019-03-01" # format YYYY-MM-DD
 
 # Test if this script is being run as root or not
 # TODO: To resolve #48, running this as root should be prohibited

--- a/installer.sh
+++ b/installer.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Increase this version number whenever you update the installer
-INSTALLER_VERSION="2019-02-25" # format YYYY-MM-DD
+INSTALLER_VERSION="2019-02-27" # format YYYY-MM-DD
 
 # Test if this script is being run as root or not
 # TODO: To resolve #48, running this as root should be prohibited
@@ -631,7 +631,8 @@ elif [ "$INITSYSTEM" = "systemd" ]; then
 		[Unit]
 		Description=ioBroker Server
 		Documentation=http://iobroker.net
-		After=network.target
+		After=network.target redis.service
+		Wants=redis.service
 		
 		[Service]
 		Type=simple

--- a/installer.sh
+++ b/installer.sh
@@ -568,7 +568,9 @@ if [[ "$INITSYSTEM" = "init.d" ]]; then
 		### BEGIN INIT INFO
 		# Provides:          iobroker.sh
 		# Required-Start:    \$network \$local_fs \$remote_fs
-		# Required-Stop::    \$network \$local_fs \$remote_fs
+		# Required-Stop:     \$network \$local_fs \$remote_fs
+		# Should-Start:      redis-server
+		# Should-Stop:       redis-server
 		# Default-Start:     2 3 4 5
 		# Default-Stop:      0 1 6
 		# Short-Description: starts ioBroker


### PR DESCRIPTION
We need to test this with and without redis installed. AFAIK, non-existent dependencies are silently ignored by systemd, so it shouldn't hurt to have it there even without redis.