### PR TITLE
Autodetect `bash` path to fix `command not found` on FreeBSD

### DIFF
--- a/CHANGELOG_FIXER_LINUX.md
+++ b/CHANGELOG_FIXER_LINUX.md
@@ -1,5 +1,8 @@
 # Changelog for Linux-Fixer-Script
 
+## 2019-05-21
+* Autodetect `bash` path to fix `command not found` on FreeBSD
+
 ## 2019-05-14
 * (Linux) Add iobroker user to the `audio` group
 

--- a/CHANGELOG_INSTALLER_LINUX.md
+++ b/CHANGELOG_INSTALLER_LINUX.md
@@ -1,5 +1,8 @@
 # Changelog for Linux-Installer-Script
 
+## 2019-05-21
+* Autodetect `bash` path to fix `command not found` on FreeBSD
+
 ## 2019-05-14
 * (Linux) Add iobroker user to the `audio` group
 

--- a/fix_installation.sh
+++ b/fix_installation.sh
@@ -783,7 +783,7 @@ elif [ "$INITSYSTEM" = "rc.d" ]; then
 		iobroker_pidfile=\${iobroker_pidfile-"$CONTROLLER_DIR/lib/iobroker.pid"}
 
 		PIDF=$CONTROLLER_DIR/lib/iobroker.pid
-		NODECMD=\$(which node)
+		NODECMD=\`which node\`
 
 		iobroker_start ()
 		{

--- a/fix_installation.sh
+++ b/fix_installation.sh
@@ -13,13 +13,13 @@ ROOT_GROUP="root"
 # Test which platform this script is being run on
 unamestr=$(uname)
 if [ "$unamestr" = "Linux" ]; then
-	platform="linux"
+	HOST_PLATFORM="linux"
 elif [ "$unamestr" = "Darwin" ]; then
 	# OSX and Linux are the same in terms of install procedure
-	platform="osx"
+	HOST_PLATFORM="osx"
 	ROOT_GROUP="wheel"
 elif [ "$unamestr" = "FreeBSD" ]; then
-	platform="freebsd"
+	HOST_PLATFORM="freebsd"
 	ROOT_GROUP="wheel"
 else
 	echo "Unsupported platform!"
@@ -28,7 +28,7 @@ fi
 
 # Directory where iobroker should be installed
 IOB_DIR="/opt/iobroker"
-if [ "$platform" = "osx" ]; then
+if [ "$HOST_PLATFORM" = "osx" ]; then
 	IOB_DIR="/usr/local/iobroker"
 fi
 CONTROLLER_DIR="$IOB_DIR/node_modules/iobroker.js-controller"
@@ -58,7 +58,7 @@ echo "Fix date $(date +%F)" >> $INSTALLER_INFO_FILE
 
 # The user to run ioBroker as
 IOB_USER="iobroker"
-if [ "$platform" = "osx" ]; then
+if [ "$HOST_PLATFORM" = "osx" ]; then
 	IOB_USER="$USER"
 fi
 
@@ -145,7 +145,7 @@ make_executable() {
 change_owner() {
 	user="$1"
 	file="$2"
-	if [ "$platform" == "osx" ]; then
+	if [ "$HOST_PLATFORM" == "osx" ]; then
 		owner="$user"
 	else
 		owner="$user:$user"
@@ -393,7 +393,7 @@ NUM_STEPS=3
 # ########################################################
 print_step "Installing prerequisites" 1 "$NUM_STEPS"
 # Determine the platform we operate on and select the installation routine/packages accordingly 
-case "$platform" in
+case "$HOST_PLATFORM" in
 	"linux")
 		declare -a packages=(
 			"acl" # To use setfacl
@@ -498,16 +498,16 @@ esac
 print_step "Checking ioBroker user and directory permissions" 2 "$NUM_STEPS"
 if [ "$USER" != "$IOB_USER" ]; then
 	# Ensure the user "iobroker" exists and is in the correct groups
-	if [ "$platform" = "linux" ]; then
+	if [ "$HOST_PLATFORM" = "linux" ]; then
 		create_user_linux $IOB_USER
-	elif [ "$platform" = "freebsd" ]; then
+	elif [ "$HOST_PLATFORM" = "freebsd" ]; then
 		create_user_freebsd $IOB_USER
 	fi
 fi
 
 # Make sure that the app dir belongs to the correct user
 # Don't do it on OSX, because we'll install as the current user anyways
-if [ "$platform" != "osx" ]; then
+if [ "$HOST_PLATFORM" != "osx" ]; then
 	fix_dir_permissions
 fi
 
@@ -560,7 +560,7 @@ fi
 
 # Test which init system is used:
 INITSYSTEM="unknown"
-if [[ "$platform" = "freebsd" && -d "/usr/local/etc/rc.d" ]]; then
+if [[ "$HOST_PLATFORM" = "freebsd" && -d "/usr/local/etc/rc.d" ]]; then
 	INITSYSTEM="rc.d"
 	SERVICE_FILENAME="/usr/local/etc/rc.d/iobroker"
 elif [[ `systemctl` =~ -\.mount ]] &> /dev/null; then 
@@ -569,7 +569,7 @@ elif [[ `systemctl` =~ -\.mount ]] &> /dev/null; then
 elif [[ -f /etc/init.d/cron && ! -h /etc/init.d/cron ]]; then
 	INITSYSTEM="init.d"
 	SERVICE_FILENAME="/etc/init.d/iobroker.sh"
-elif [[ "$platform" = "osx" ]]; then
+elif [[ "$HOST_PLATFORM" = "osx" ]]; then
 	INITSYSTEM="launchctl"
 	SERVICE_FILENAME="/Users/${IOB_USER}/Library/LaunchAgents/${PLIST_FILE_LABEL}.plist"
 fi
@@ -619,9 +619,9 @@ else
 		EOF
 	)
 fi
-if [ "$platform" = "linux" ]; then
+if [ "$HOST_PLATFORM" = "linux" ]; then
 	IOB_BIN_PATH=/usr/bin
-elif [ "$platform" = "freebsd" ] || [ "$platform" = "osx" ]; then
+elif [ "$HOST_PLATFORM" = "freebsd" ] || [ "$HOST_PLATFORM" = "osx" ]; then
 	IOB_BIN_PATH=/usr/local/bin
 fi
 # First remove the old binaries and symlinks

--- a/installer.sh
+++ b/installer.sh
@@ -820,6 +820,17 @@ else
 	echo "Autostart: false" >> $INSTALLER_INFO_FILE
 fi
 
+# Test again which platform this script is being run on
+# This is necessary because FreeBSD does crazy stuff
+unamestr=$(uname)
+if [ "$unamestr" = "Linux" ]; then
+	HOST_PLATFORM="linux"
+elif [ "$unamestr" = "Darwin" ]; then
+	HOST_PLATFORM="osx"
+elif [ "$unamestr" = "FreeBSD" ]; then
+	HOST_PLATFORM="freebsd"
+fi
+
 # Make sure that the app dir belongs to the correct user
 # Don't do it on OSX, because we'll install as the current user anyways
 echo "Before fixing dir permissions..."

--- a/installer.sh
+++ b/installer.sh
@@ -822,9 +822,12 @@ fi
 
 # Make sure that the app dir belongs to the correct user
 # Don't do it on OSX, because we'll install as the current user anyways
+echo "Before fixing dir permissions..."
+echo "platform = $platform"
 if [ "$platform" != "osx" ]; then
 	fix_dir_permissions
 fi
+echo "After fixing dir permissions..."
 
 unset AUTOMATED_INSTALLER
 

--- a/installer.sh
+++ b/installer.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-set -x
-
 # Increase this version number whenever you update the installer
 INSTALLER_VERSION="2019-05-21" # format YYYY-MM-DD
 

--- a/installer.sh
+++ b/installer.sh
@@ -14,23 +14,17 @@ else
 fi
 ROOT_GROUP="root"
 # Test which platform this script is being run on
-get_platform() {
-	unamestr=$(uname)
-	local platform=""
-	if [ "$unamestr" = "Linux" ]; then
-		platform="linux"
-	elif [ "$unamestr" = "Darwin" ]; then
-		# OSX and Linux are the same in terms of install procedure
-		platform="osx"
-		ROOT_GROUP="wheel"
-	elif [ "$unamestr" = "FreeBSD" ]; then
-		platform="freebsd"
-		ROOT_GROUP="wheel"
-	fi
-	echo "$platform"
-}
-platform=$(get_platform)
-if [ "$platform" = "" ]; then
+unamestr=$(uname)
+if [ "$unamestr" = "Linux" ]; then
+	platform="linux"
+elif [ "$unamestr" = "Darwin" ]; then
+	# OSX and Linux are the same in terms of install procedure
+	platform="osx"
+	ROOT_GROUP="wheel"
+elif [ "$unamestr" = "FreeBSD" ]; then
+	platform="freebsd"
+	ROOT_GROUP="wheel"
+else
 	echo "Unsupported platform!"
 	exit 1
 fi
@@ -774,7 +768,7 @@ elif [ "$INITSYSTEM" = "rc.d" ]; then
 	# Enable startup and start the service
 	sysrc iobroker_enable=YES
 	service iobroker start
-
+	
 	echo "Autostart enabled!"
 	echo "Autostart: rc.d" >> $INSTALLER_INFO_FILE
 
@@ -825,10 +819,6 @@ else
 	echo "${yellow}Unsupported init system, cannot enable autostart!${normal}"
 	echo "Autostart: false" >> $INSTALLER_INFO_FILE
 fi
-
-# FreeBSD seems to reset this variable somehow
-# There must be a better way, but I don't know how
-platform=$(get_platform)
 
 # Make sure that the app dir belongs to the correct user
 # Don't do it on OSX, because we'll install as the current user anyways

--- a/installer.sh
+++ b/installer.sh
@@ -831,12 +831,9 @@ fi
 
 # Make sure that the app dir belongs to the correct user
 # Don't do it on OSX, because we'll install as the current user anyways
-echo "Before fixing dir permissions..."
-echo "platform = $HOST_PLATFORM"
 if [ "$HOST_PLATFORM" != "osx" ]; then
 	fix_dir_permissions
 fi
-echo "After fixing dir permissions..."
 
 unset AUTOMATED_INSTALLER
 

--- a/installer.sh
+++ b/installer.sh
@@ -728,7 +728,7 @@ elif [ "$INITSYSTEM" = "rc.d" ]; then
 		iobroker_pidfile=\${iobroker_pidfile-"$CONTROLLER_DIR/lib/iobroker.pid"}
 
 		PIDF=$CONTROLLER_DIR/lib/iobroker.pid
-		NODECMD=\$(which node)
+		NODECMD=\`which node\`
 
 		iobroker_start ()
 		{

--- a/installer.sh
+++ b/installer.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -x
+
 # Increase this version number whenever you update the installer
 INSTALLER_VERSION="2019-05-21" # format YYYY-MM-DD
 

--- a/installer.sh
+++ b/installer.sh
@@ -14,17 +14,23 @@ else
 fi
 ROOT_GROUP="root"
 # Test which platform this script is being run on
-unamestr=$(uname)
-if [ "$unamestr" = "Linux" ]; then
-	platform="linux"
-elif [ "$unamestr" = "Darwin" ]; then
-	# OSX and Linux are the same in terms of install procedure
-	platform="osx"
-	ROOT_GROUP="wheel"
-elif [ "$unamestr" = "FreeBSD" ]; then
-	platform="freebsd"
-	ROOT_GROUP="wheel"
-else
+get_platform() {
+	unamestr=$(uname)
+	local platform=""
+	if [ "$unamestr" = "Linux" ]; then
+		platform="linux"
+	elif [ "$unamestr" = "Darwin" ]; then
+		# OSX and Linux are the same in terms of install procedure
+		platform="osx"
+		ROOT_GROUP="wheel"
+	elif [ "$unamestr" = "FreeBSD" ]; then
+		platform="freebsd"
+		ROOT_GROUP="wheel"
+	fi
+	echo "$platform"
+}
+platform=$(get_platform)
+if [ "$platform" = "" ]; then
 	echo "Unsupported platform!"
 	exit 1
 fi
@@ -768,7 +774,7 @@ elif [ "$INITSYSTEM" = "rc.d" ]; then
 	# Enable startup and start the service
 	sysrc iobroker_enable=YES
 	service iobroker start
-	
+
 	echo "Autostart enabled!"
 	echo "Autostart: rc.d" >> $INSTALLER_INFO_FILE
 
@@ -819,6 +825,10 @@ else
 	echo "${yellow}Unsupported init system, cannot enable autostart!${normal}"
 	echo "Autostart: false" >> $INSTALLER_INFO_FILE
 fi
+
+# FreeBSD seems to reset this variable somehow
+# There must be a better way, but I don't know how
+platform=$(get_platform)
 
 # Make sure that the app dir belongs to the correct user
 # Don't do it on OSX, because we'll install as the current user anyways


### PR DESCRIPTION
As discussed here:
https://forum.iobroker.net/topic/22293/neue-installation-auf-freebsd-freenas-11-2-funktioniert-nicht/

DON'T MERGE YET!