### PR TITLE
Include `PATH` env variable in OSX startup script

### DIFF
--- a/CHANGELOG_FIXER_LINUX.md
+++ b/CHANGELOG_FIXER_LINUX.md
@@ -1,5 +1,8 @@
 # Changelog for Linux-Fixer-Script
 
+## 2019-07-03
+* Include `PATH` environment variable in OSX startup script
+
 ## 2019-06-29
 * Add install fixer as iobroker shortcut via "iobroker fix"
 

--- a/CHANGELOG_INSTALLER_LINUX.md
+++ b/CHANGELOG_INSTALLER_LINUX.md
@@ -1,5 +1,8 @@
 # Changelog for Linux-Installer-Script
 
+## 2019-07-03
+* Include `PATH` environment variable in OSX startup script
+
 ## 2019-06-29
 * Add install fixer as iobroker shortcut via "iobroker fix"
 

--- a/fix_installation.sh
+++ b/fix_installation.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Increase this version number whenever you update the fixer
-FIXER_VERSION="2019-06-29" # format YYYY-MM-DD
+FIXER_VERSION="2019-07-03" # format YYYY-MM-DD
 
 # Test if this script is being run as root or not
 if [[ $EUID -eq 0 ]]; then
@@ -857,6 +857,10 @@ elif [ "$INITSYSTEM" = "launchctl" ]; then
 			<true/>
 			<key>RunAtLoad</key>
 			<true/>
+			<dict>
+				<key>PATH</key>
+				<string>/usr/local/bin:/usr/local/sbin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+			</dict>
 		</dict>
 		</plist>
 		EOF

--- a/installer.sh
+++ b/installer.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Increase this version number whenever you update the installer
-INSTALLER_VERSION="2019-06-29" # format YYYY-MM-DD
+INSTALLER_VERSION="2019-07-03" # format YYYY-MM-DD
 
 # Test if this script is being run as root or not
 # TODO: To resolve #48, running this as root should be prohibited
@@ -804,6 +804,11 @@ elif [ "$INITSYSTEM" = "launchctl" ]; then
 			<true/>
 			<key>RunAtLoad</key>
 			<true/>
+			<key>EnvironmentVariables</key>
+			<dict>
+				<key>PATH</key>
+				<string>/usr/local/bin:/usr/local/sbin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+			</dict>
 		</dict>
 		</plist>
 


### PR DESCRIPTION
Fixes `command not found` errors, see https://forum.iobroker.net/topic/20597/iobroker-auf-mac-fehlermeldung/8