### PR TITLE
Add `/sbin` to `PATH` at the start of the script

### DIFF
--- a/CHANGELOG_FIXER_LINUX.md
+++ b/CHANGELOG_FIXER_LINUX.md
@@ -1,5 +1,8 @@
 # Changelog for Linux-Fixer-Script
 
+## 2019-07-17
+* Fix for Debian 10: Add `/sbin` and similar directories to `PATH` at the start of the script
+
 ## 2019-07-03
 * Include `PATH` environment variable in OSX startup script
 

--- a/CHANGELOG_INSTALLER_LINUX.md
+++ b/CHANGELOG_INSTALLER_LINUX.md
@@ -1,5 +1,8 @@
 # Changelog for Linux-Installer-Script
 
+## 2019-07-17
+* Fix for Debian 10: Add `/sbin` and similar directories to `PATH` at the start of the script
+
 ## 2019-07-03
 * Include `PATH` environment variable in OSX startup script
 

--- a/fix_installation.sh
+++ b/fix_installation.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Increase this version number whenever you update the fixer
-FIXER_VERSION="2019-07-03" # format YYYY-MM-DD
+FIXER_VERSION="2019-07-17" # format YYYY-MM-DD
 
 # Test if this script is being run as root or not
 if [[ $EUID -eq 0 ]]; then
@@ -25,6 +25,20 @@ else
 	echo "Unsupported platform!"
 	exit 1
 fi
+
+# Adds dirs to the PATH variable without duplicating entries
+add_to_path() {
+	case ":$PATH:" in
+		*":$1:"*) :;; # already there
+		*) PATH="$1:$PATH";;
+	esac
+}
+# Starting with Debian 10 (Buster), we need to add the [/usr[/local]]/sbin
+# directories to PATH for non-root users
+if [ -d "/sbin" ]; then add_to_path "/sbin"; fi
+if [ -d "/usr/sbin" ]; then add_to_path "/usr/sbin"; fi
+if [ -d "/usr/local/sbin" ]; then add_to_path "/usr/local/sbin"; fi
+
 
 # Directory where iobroker should be installed
 IOB_DIR="/opt/iobroker"

--- a/installer.sh
+++ b/installer.sh
@@ -1,10 +1,9 @@
 #!/bin/bash
 
 # Increase this version number whenever you update the installer
-INSTALLER_VERSION="2019-07-03" # format YYYY-MM-DD
+INSTALLER_VERSION="2019-07-17" # format YYYY-MM-DD
 
 # Test if this script is being run as root or not
-# TODO: To resolve #48, running this as root should be prohibited
 if [[ $EUID -eq 0 ]]; then
 	IS_ROOT=true
 else
@@ -26,6 +25,19 @@ else
 	echo "Unsupported platform!"
 	exit 1
 fi
+
+# Adds dirs to the PATH variable without duplicating entries
+add_to_path() {
+	case ":$PATH:" in
+		*":$1:"*) :;; # already there
+		*) PATH="$1:$PATH";;
+	esac
+}
+# Starting with Debian 10 (Buster), we need to add the [/usr[/local]]/sbin
+# directories to PATH for non-root users
+if [ -d "/sbin" ]; then add_to_path "/sbin"; fi
+if [ -d "/usr/sbin" ]; then add_to_path "/usr/sbin"; fi
+if [ -d "/usr/local/sbin" ]; then add_to_path "/usr/local/sbin"; fi
 
 # Directory where iobroker should be installed
 IOB_DIR="/opt/iobroker"


### PR DESCRIPTION
Fixes installation on Debian Buster by adding the three known locations of `sbin` to the path if they aren't already there.