### PR TITLE
Emergency fix to last change: escape `$` in `$(pwd)`

### DIFF
--- a/CHANGELOG_FIXER_LINUX.md
+++ b/CHANGELOG_FIXER_LINUX.md
@@ -1,5 +1,8 @@
 # Changelog for Linux-Fixer-Script
 
+## 2019-10-18
+* Emergency fix to last change: escape `$` in `$(pwd)`
+
 ## 2019-10-13
 * Always run `npm` as iobroker when inside installation dir
 

--- a/CHANGELOG_INSTALLER_LINUX.md
+++ b/CHANGELOG_INSTALLER_LINUX.md
@@ -1,5 +1,8 @@
 # Changelog for Linux-Installer-Script
 
+## 2019-10-18
+* Emergency fix to last change: escape `$` in `$(pwd)`
+
 ## 2019-10-13
 * Always run `npm` as iobroker when inside installation dir
 

--- a/fix_installation.sh
+++ b/fix_installation.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Increase this version number whenever you update the fixer
-FIXER_VERSION="2019-10-13" # format YYYY-MM-DD
+FIXER_VERSION="2019-10-18" # format YYYY-MM-DD
 
 # Test if this script is being run as root or not
 if [[ $EUID -eq 0 ]]; then
@@ -127,7 +127,7 @@ change_npm_command_user() {
 		# While inside the iobroker directory, execute npm as iobroker
 		function npm() {
 			__real_npm=\$(which npm)
-			if [[ $(pwd) == "$IOB_DIR"* ]]; then
+			if [[ \$(pwd) == "$IOB_DIR"* ]]; then
 				sudo -H -u $IOB_USER \$__real_npm \$*
 			else
 				eval \$__real_npm \$*

--- a/installer.sh
+++ b/installer.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Increase this version number whenever you update the installer
-INSTALLER_VERSION="2019-10-13" # format YYYY-MM-DD
+INSTALLER_VERSION="2019-10-18" # format YYYY-MM-DD
 
 # Test if this script is being run as root or not
 if [[ $EUID -eq 0 ]]; then
@@ -300,7 +300,7 @@ change_npm_command_user() {
 		# While inside the iobroker directory, execute npm as iobroker
 		function npm() {
 			__real_npm=\$(which npm)
-			if [[ $(pwd) == "$IOB_DIR"* ]]; then
+			if [[ \$(pwd) == "$IOB_DIR"* ]]; then
 				sudo -H -u $IOB_USER \$__real_npm \$*
 			else
 				eval \$__real_npm \$*


### PR DESCRIPTION
Bug found in https://github.com/ioBroker/ioBroker/pull/211 - we need to make sure to not affect too many installations!