### PR TITLE
Add argument wildcard to iobroker CLI

### DIFF
--- a/CHANGELOG_FIXER_LINUX.md
+++ b/CHANGELOG_FIXER_LINUX.md
@@ -1,5 +1,8 @@
 # Changelog for Linux-Fixer-Script
 
+## 2020-04-12
+* (Linux) Avoid entering the sudo password for iobroker CLI
+
 ## 2020-01-30
 * (Linux) Add iobroker user to the `video` group
 

--- a/CHANGELOG_INSTALLER_LINUX.md
+++ b/CHANGELOG_INSTALLER_LINUX.md
@@ -1,5 +1,8 @@
 # Changelog for Linux-Installer-Script
 
+## 2020-04-12
+* (Linux) Avoid entering the sudo password for iobroker CLI
+
 ## 2020-01-30
 * (Linux) Add iobroker user to the `video` group
 

--- a/fix_installation.sh
+++ b/fix_installation.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Increase this version number whenever you update the fixer
-FIXER_VERSION="2020-01-25" # format YYYY-MM-DD
+FIXER_VERSION="2020-04-12" # format YYYY-MM-DD
 
 # Test if this script is being run as root or not
 if [[ $EUID -eq 0 ]];

--- a/installer.sh
+++ b/installer.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Increase this version number whenever you update the installer
-INSTALLER_VERSION="2020-01-25" # format YYYY-MM-DD
+INSTALLER_VERSION="2020-04-12" # format YYYY-MM-DD
 
 # Test if this script is being run as root or not
 if [[ $EUID -eq 0 ]];

--- a/installer_library.sh
+++ b/installer_library.sh
@@ -1,7 +1,7 @@
 # ------------------------------
 # Increase this version number whenever you update the lib
 # ------------------------------
-LIBRARY_VERSION="2020-01-30" # format YYYY-MM-DD
+LIBRARY_VERSION="2020-04-12" # format YYYY-MM-DD
 
 # ------------------------------
 # Supported and suggested node versions
@@ -566,7 +566,7 @@ create_user_linux() {
 
 	# Furthermore, allow all users to execute node iobroker.js as iobroker
 	if [ "$IOB_USER" != "$USER" ]; then
-		add2sudoers "ALL ALL=($IOB_USER) " "node $CONTROLLER_DIR/iobroker.js"
+		add2sudoers "ALL ALL=($IOB_USER) " "node $CONTROLLER_DIR/iobroker.js *"
 	fi
 
 	SUDOERS_FILE="/etc/sudoers.d/iobroker"


### PR DESCRIPTION
As discussed in Telegram, the iobroker CLI used to ask for the password when running commands like `iobroker status`. This is not intended and was probably caused by a wrong sudoers entry, which did not match the arguments passed from the CLI script.

Draft for now until I have confirmation this works.