### PR TITLE
Fixed installer_library.sh download URL

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -12,7 +12,7 @@ USER_GROUP="$USER"
 
 # get and load the LIB => START
 LIB_NAME="installer_library.sh"
-LIB_URL="https://raw.githubusercontent.com/ioBroker/ioBroker/stable-installer/$LIB_NAME"
+LIB_URL="https://raw.githubusercontent.com/ioBroker/ioBroker/master/$LIB_NAME"
 curl -sL $LIB_URL > ~/$LIB_NAME
 if test -f ~/$LIB_NAME; then source ~/$LIB_NAME; else echo "Installer/Fixer: library not found"; exit -2; fi
 # Delete the lib again. We have sourced it so we don't need it anymore


### PR DESCRIPTION
Download URL for installer_library.sh is broken. Adjusted URL to location of master branch.