### PR TITLE
Updated Recommended Node.JS and NPM Version to 12.x LTS

### DIFF
--- a/CHANGELOG_INSTALLER_LINUX.md
+++ b/CHANGELOG_INSTALLER_LINUX.md
@@ -1,5 +1,8 @@
 # Changelog for Linux-Installer-Script
 
+## 2020-06-19 
+* (Linux) Updated Recommended Node.JS and NPM Version to 12.x LTS and improved CheckVersions Output for the user
+
 ## 2020-06-12
 * (Linux) Added net-tools to fix error #277 "ifconfig: command not found" 
 * (Linux) correctly parse string arguments inside quotes

--- a/lib/checkVersions.js
+++ b/lib/checkVersions.js
@@ -12,7 +12,7 @@ const semver = require('semver');
 
 // DEFINE minimum versions here:
 /** The minimum required Node.JS version - should be the current LTS */
-const MIN_NODE_VERSION = '12.13.0';
+const MIN_NODE_VERSION = '10.21.0';
 /** The recommended npm version - should be the one bundled with MIN_NODE_VERSION */
 const RECOMMENDED_NPM_VERSION = '6.12.0';
 /** The minimum supported npm version - should probably be the same major version as RECOMMENDED_NPM_VERSION*/

--- a/lib/checkVersions.js
+++ b/lib/checkVersions.js
@@ -12,9 +12,9 @@ const semver = require('semver');
 
 // DEFINE minimum versions here:
 /** The minimum required Node.JS version - should be the current LTS */
-const MIN_NODE_VERSION = '8.12';
+const MIN_NODE_VERSION = '12.13.0';
 /** The recommended npm version - should be the one bundled with MIN_NODE_VERSION */
-const RECOMMENDED_NPM_VERSION = '6.4.1';
+const RECOMMENDED_NPM_VERSION = '6.12.0';
 /** The minimum supported npm version - should probably be the same major version as RECOMMENDED_NPM_VERSION*/
 const MIN_NPM_VERSION = '6.0.0';
 
@@ -63,7 +63,10 @@ if (versions.node && semver.lt(versions.node, semver.coerce(MIN_NODE_VERSION))) 
     console.error('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!');
     console.error(`ioBroker needs at least Node.JS ${MIN_NODE_VERSION}. You have installed ${versions.node}`);
     console.error('Please update your Node.JS version!');
-    // TODO: Print manual how to update NodeJS
+    console.error('To Update to the latest Node.JS 12.x Release you can use ')
+    console.error('"curl -sL https://deb.nodesource.com/setup_12.x | sudo -E bash - \
+                     &&  sudo apt-get install -y nodejs"')
+    console.error('More information is available at https://github.com/nodesource/distributions/')
     console.error('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!');
     process.exit(2);
 }
@@ -72,7 +75,7 @@ if (versions.npm == null) {
     console.error('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!');
     console.error('Aborting install because the npm version could not be checked!');
     console.error('Please check that npm is installed correctly.');
-    console.error('Use "npm install -g npm" to install a supported version.');
+    console.error(`Use "npm install -g npm@${RECOMMENDED_NPM_VERSION}" to install a supported version.`);
     console.error('You need to make sure to repeat this step after installing an update to NodeJS and/or npm.');
     console.error('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!');
     process.exit(3);
@@ -81,7 +84,7 @@ if (versions.npm == null) {
 if (semver.lt(versions.npm, semver.coerce(MIN_NPM_VERSION))) {
     console.error('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!');
     console.error(`You are using npm ${versions.npm}, but ioBroker needs at least using ${MIN_NPM_VERSION}.`);
-    console.error('Please use "npm install -g npm" to install a supported version!');
+    console.error(`Please use "npm install -g npm@${RECOMMENDED_NPM_VERSION}" to install a supported version!`);
     console.error('You need to make sure to repeat this step after installing an update to NodeJS and/or npm.');
     console.error('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!');
     process.exit(4);
@@ -90,7 +93,7 @@ if (semver.lt(versions.npm, semver.coerce(MIN_NPM_VERSION))) {
 if (semver.lt(versions.npm, semver.coerce(RECOMMENDED_NPM_VERSION))) {
     console.warn('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!');
     console.warn(`You are using npm ${versions.npm}, but ioBroker recommends using ${RECOMMENDED_NPM_VERSION}.`);
-    console.warn('Consider using "npm install -g npm" to install the newest version!');
+    console.warn(`Consider using "npm install -g npm@${RECOMMENDED_NPM_VERSION}" to install the newest version!`);
     console.warn('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!');
 }
 


### PR DESCRIPTION
As mentioned in Issue #88  the installer should be limited to the minimum NodeJS Version, which now should be version 12.x as I know. So I modified that in the Check Libary and added some output, so the user (only for Linux systems) can update the NodeJS version and reference the official node js upgrade procedure. 

I'm not sure if there any other changed necessary to fulfill issue #88 to get fixed? 