### PR TITLE
Revert "fix npm permissions fix if `which` is an alias"

### DIFF
--- a/installer_library.sh
+++ b/installer_library.sh
@@ -429,7 +429,7 @@ change_npm_command_user() {
 	NPM_COMMAND_FIX=$(cat <<- EOF
 		# While inside the iobroker directory, execute npm as iobroker
 		function npm() {
-			__real_npm=\$(which --skip-alias --skip-functions npm)
+			__real_npm=\$(which npm)
 			if [[ \$(pwd) == "$IOB_DIR"* ]]; then
 				sudo -H -u $IOB_USER \$__real_npm \$*
 			else


### PR DESCRIPTION
Reverts ioBroker/ioBroker#316

This breaks debian:
![grafik](https://user-images.githubusercontent.com/17641229/105544605-70908c00-5cfb-11eb-8dad-3d1942d19adf.png)
