### PR TITLE
Extend Docker check in installer

### DIFF
--- a/CHANGELOG_INSTALLER_LINUX.md
+++ b/CHANGELOG_INSTALLER_LINUX.md
@@ -1,5 +1,8 @@
 # Changelog for Linux-Installer-Script
 
+## 2022-11-02
+* Add condition for checking if installer runs in Docker environment
+
 ## 2022-06-03
 * Remove python-dev from installed debian packages again to prevent installing python2 on some distributions
 

--- a/installer_library.sh
+++ b/installer_library.sh
@@ -441,7 +441,7 @@ function append_to_file() {
 
 running_in_docker() {
 	# Test if we're running inside a docker container or as github actions job while building docker container image
-	if awk -F/ '$2 == "docker"' /proc/self/cgroup | read || awk -F/ '$2 == "actions_job"' /proc/self/cgroup | read ; then
+	if awk -F/ '$2 == "docker"' /proc/self/cgroup | read || awk -F/ '$2 == "actions_job"' /proc/self/cgroup | read || test -f /opt/scripts/.docker_config/.thisisdocker ; then
 		return 0
 	else
 		return 1

--- a/installer_library.sh
+++ b/installer_library.sh
@@ -441,7 +441,7 @@ function append_to_file() {
 
 running_in_docker() {
 	# Test if we're running inside a docker container or as github actions job while building docker container image
-	if awk -F/ '$2 == "docker"' /proc/self/cgroup | read || awk -F/ '$2 == "actions_job"' /proc/self/cgroup | read || test -f /opt/scripts/.docker_config/.thisisdocker ; then
+	if awk -F/ '$2 == "docker"' /proc/self/cgroup | read || awk -F/ '$2 == "actions_job"' /proc/self/cgroup | read || test -f /.dockerenv || test -f /opt/scripts/.docker_config/.thisisdocker ; then
 		return 0
 	else
 		return 1


### PR DESCRIPTION
Hi,
according to https://github.com/ioBroker/ioBroker.js-controller/pull/2038 I tried to adapt the changes for the Docker check at the ioBroker installer.
This should also be a possible solution for #380.   

Regards,
André