### PR TITLE
Suggestion: Remove CLS from serviceIoBroker.bat

### DIFF
--- a/install/windows/serviceIoBroker.bat
+++ b/install/windows/serviceIoBroker.bat
@@ -2,7 +2,6 @@
 :: Automatically check & get admin rights
 :::::::::::::::::::::::::::::::::::::::::
 @echo off
-CLS
 ECHO.
 ECHO =============================
 ECHO Running Admin shell


### PR DESCRIPTION
Under windows, logs are very hard to read on the screen, if a command calls servicioBroker.bat. That's because the screen is wiped several times (e.g. @iobroker/fix). Since the CLS has not really a benefit, I suggest to remove it.