### PR TITLE
Windows Installer: Make the windows service name configurable and create start menu entries

### DIFF
--- a/CHANGELOG_DIAG_LINUX.md
+++ b/CHANGELOG_DIAG_LINUX.md
@@ -1,5 +1,9 @@
 # Changelog for Linux-Diag-Script
 
+## 2022-12-31
+* Added tail -n 25 for iob logs
+* Added status of admin in Summary
+
 ## 2022-12-30
 * Added some more checks
 

--- a/install/windows/install.js
+++ b/install/windows/install.js
@@ -1,9 +1,13 @@
 'use strict';
 
 const Service = require('node-windows').Service;
+const Shortcuts = require('./shortcuts')
 
 // Get environment variables from file .env 
 require('dotenv').config();
+
+// Create the according Windows startmenu entries
+Shortcuts.createStartMenu();
 
 // Create a new service object
 const svc = new Service({

--- a/install/windows/install.js
+++ b/install/windows/install.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const Service = require('node-windows').Service;
-const Shortcuts = require('./shortcuts')
+const Shortcuts = require('./shortcuts');
 
 // Get environment variables from file .env 
 require('dotenv').config();

--- a/install/windows/install.js
+++ b/install/windows/install.js
@@ -2,9 +2,12 @@
 
 const Service = require('node-windows').Service;
 
+// Get environment variables from file .env 
+require('dotenv').config();
+
 // Create a new service object
 const svc = new Service({
-    name: 'ioBroker',
+    name: process.env.iobServiceName ? process.env.iobServiceName : 'ioBroker',
     description: 'ioBroker service.',
     script: require('path').join(__dirname, 'controller.js'),
     env: {

--- a/install/windows/serviceIoBroker.bat
+++ b/install/windows/serviceIoBroker.bat
@@ -2,7 +2,6 @@
 :: Automatically check & get admin rights
 :::::::::::::::::::::::::::::::::::::::::
 @echo off
-CLS
 ECHO.
 ECHO =============================
 ECHO Running Admin shell
@@ -39,13 +38,14 @@ cd /d %~dp0
 ::::::::::::::::::::::::::::
 ::START
 ::::::::::::::::::::::::::::
-if '%1' == 'start' %WINDIR%\system32\net.exe start ioBroker
-if '%1' == 'stop' %WINDIR%\system32\net.exe stop ioBroker
+call setEnvIobServiceName.bat
+if '%1' == 'start' %WINDIR%\system32\net.exe start %iobServiceName%
+if '%1' == 'stop' %WINDIR%\system32\net.exe stop %iobServiceName%
 if '%1' == '' (
-	%WINDIR%\system32\net.exe stop ioBroker
-	%WINDIR%\system32\net.exe start ioBroker
+	%WINDIR%\system32\net.exe stop %iobServiceName%
+	%WINDIR%\system32\net.exe start %iobServiceName%
 )
 if '%1' == 'restart' (
-	%WINDIR%\system32\net.exe stop ioBroker
-	%WINDIR%\system32\net.exe start ioBroker
+	%WINDIR%\system32\net.exe stop %iobServiceName%
+	%WINDIR%\system32\net.exe start %iobServiceName%
 )

--- a/install/windows/setEnvIobServiceName.bat
+++ b/install/windows/setEnvIobServiceName.bat
@@ -1,0 +1,6 @@
+@echo off
+for /F "tokens=*" %%I in (.env) do set %%I
+if not defined iobServiceName (
+	set iobServiceName=ioBroker
+)
+echo ioBroker service name: %iobServiceName%

--- a/install/windows/shortcuts.js
+++ b/install/windows/shortcuts.js
@@ -120,7 +120,7 @@ function createStartMenu() {
         'echo.\n' +
         `call "${nodeVarsBat}"\n` +
         `cd ${process.cwd()}\n` +
-        `${path.parse(process.cwd()).root.replace('\\', '')}\n`;
+        `${path.parse(process.cwd()).root.replace(/\\/g, '')}\n`;
 
     try {
         fs.writeFileSync(ioNodeVarsBat, content);

--- a/install/windows/shortcuts.js
+++ b/install/windows/shortcuts.js
@@ -1,0 +1,218 @@
+'use strict';
+
+const ws = require('windows-shortcuts');
+const fs = require('fs');
+const path = require('path');
+
+// Get environment variables from file .env
+require('dotenv').config();
+
+//
+// Get the name of a start menu entry
+//
+function getFullLinkFileName(menuDir, linkFileName, serviceName) {
+    return path.join(menuDir, serviceName ? `[${serviceName}] ${linkFileName}` : linkFileName);
+}
+
+//
+// Create one startmenu entry and the according folder if not already created
+//
+function createStartMenuEntry(menuDir, linkFileName, serviceName, target, workingDir, args, desc, iconFileName, admin) {
+
+    if (!fs.existsSync(menuDir)) {
+        try {
+            fs.mkdirSync(menuDir);
+            console.log(`Startmenu folder ${sMenuDir} created!`);
+        }
+        catch (err) {
+            console.error(`Error occurred when reating startmenu folder ${sMenuDir}!`);
+            console.error(err);
+        }
+    }
+
+    const fullLinkFileName = getFullLinkFileName(menuDir, linkFileName, serviceName);
+
+    ws.create(fullLinkFileName, {
+        target: target,
+        runStyle: 1,
+        workingDir: workingDir,
+        args: args,
+        desc: desc,
+        icon: iconFileName
+    }, function (err) {
+        if (err) {
+            console.error(`Error occurred when creating shortcut ${fullLinkFileName}`);
+            console.error(err);
+        }
+        else {
+            if (admin) {
+                fs.readFile(fullLinkFileName, function (err, data) {
+                    if (err) {
+                        console.error(`Shortcut "${fullLinkFileName}" could not be opened to set Admin flag!`);
+                        console.error(err);
+                    }
+                    else {
+                        try {
+                            data[0x15] |= 0x20;
+                            fs.writeFileSync(fullLinkFileName, data);
+                            console.log(`Shortcut "${fullLinkFileName}" created with Admin flag!`);
+                        }
+                        catch (err) {
+                            console.error(`Shortcut "${fullLinkFileName}" could not be written to set Admin flag!`);
+                            console.error(err);
+                        }
+                    }
+                });
+            }
+            else {
+                console.log(`Shortcut "${fullLinkFileName}" created!`);
+            }
+        };
+    });
+}
+
+//
+// Remove one startmenu entry
+//
+async function removeStartMenuEntry(menuDir, linkFileName, serviceName) {
+
+    const fullLinkFileName = getFullLinkFileName(menuDir, linkFileName, serviceName);
+    try {
+        fs.rmSync(fullLinkFileName);
+        console.log(`Shortcut "${fullLinkFileName}" removed!`);
+    }
+    catch (err) {
+        if (err.code === 'ENOENT') {
+            console.log(`Shortcut "${fullLinkFileName}" not removed, because it was not found!`);
+        }
+        else {
+            console.error(`Error occurred when removing shortcut ${fullLinkFileName}`);
+            console.error(err);
+        }
+    }
+}
+
+const iobServiceName = process.env.iobServiceName;
+const sMenuDir = `${process.env.ALLUSERSPROFILE}\\Microsoft\\Windows\\Start Menu\\Programs\\ioBroker automation platform`;
+const nodeVarsBat = path.join(path.dirname(process.execPath), 'nodevars.bat');
+const ioNodeVarsBat = path.join(`${process.cwd()}`, 'iobnodevars.bat');
+const linkCmdLine = 'ioBroker Command line.lnk';
+const linkAdmin = 'ioBroker Admin.lnk';
+const linkStartService = 'Start ioBroker Service.lnk';
+const linkStopService = 'Stop ioBroker Service.lnk';
+const linkRestartService = 'Restart ioBroker Service.lnk';
+const iconPath = path.join(process.cwd(), '\\node_modules\\iobroker.admin\\www\\favicon.ico');
+const servicePath = path.join(process.cwd(), 'serviceiobroker.bat');
+
+//
+// Create all startmenu entries and the startmenu folder
+//
+function createStartMenu() {
+    const content = '@echo off\n' +
+        'echo.\n' +
+        'echo **********************************************************\n' +
+        'echo ***               Welcome to ioBroker.                 ***\n' +
+        'echo ***                                                    ***\n' +
+        'echo ***     Type \'iob help\' for list of instructions.      ***\n' +
+        'echo ***                For more help see                   ***\n' +
+        'echo ***     https://github.com/ioBroker/ioBroker.docs      ***\n' +
+        'echo **********************************************************\n' +
+        'echo.\n' +
+        `call "${nodeVarsBat}"\n` +
+        `cd ${process.cwd()}\n` +
+        `${path.parse(process.cwd()).root.replace('\\', '')}\n`;
+
+    try {
+        fs.writeFileSync(ioNodeVarsBat, content);
+        console.log('Written iobnodevars.bat successfully.');
+    } catch (err) {
+        console.error(`Error occurred when creating file ${nodeVarsBat}`);
+        console.error(err);
+    }
+
+    createStartMenuEntry(
+        sMenuDir,                    // Directory in start menu
+        linkCmdLine,                 // Shortcut filename
+        iobServiceName,              // Servicename, empty string for standard name iobroker
+        process.env.ComSpec,         // target, in this case cmd.exe
+        process.cwd(),               // ioBroker root directory
+        '/k "' + ioNodeVarsBat + '"',// parameter of shortcut, in this case path to nodevars.bat
+        'ioBroker Command line.',    // description
+        iconPath,
+        true
+    );
+
+    createStartMenuEntry(
+        sMenuDir,                             // Directory in start menu
+        linkAdmin,                            // Shortcut filename
+        iobServiceName,                       // Servicename, empty string for standard name iobroker
+        'http://127.0.0.1:8081',              // target
+        process.cwd(),                        // ioBroker root directory
+        '',                                   // parameter of shortcut
+        'Open ioBroker Admin in Web Browser.',// description
+        iconPath,
+        false
+    );
+
+    createStartMenuEntry(
+        sMenuDir,                    // Directory in start menu
+        linkStartService,            // Shortcut filename
+        iobServiceName,              // Servicename, empty string for standard name iobroker
+        servicePath,  // target
+        process.cwd(),               // ioBroker root directory
+        'start',                     // parameter of shortcut
+        'Start ioBroker service.',   // description
+        '',
+        true
+    );
+
+    createStartMenuEntry(
+        sMenuDir,                    // Directory in start menu
+        linkStopService,             // Shortcut filename
+        iobServiceName,              // Servicename, empty string for standard name iobroker
+        servicePath, // target
+        process.cwd(),               // ioBroker root directory
+        'stop',                      // parameter of shortcut
+        'Stop ioBroker service.',    // description
+        '',
+        true
+    );
+
+    createStartMenuEntry(
+        sMenuDir,                      // Directory in start menu
+        linkRestartService,            // Shortcut filename
+        iobServiceName,                // Servicename, empty string for standard name iobroker
+        servicePath,                   // target
+        process.cwd(),                 // ioBroker root directory
+        'restart',                     // parameter of shortcut
+        'Restart ioBroker service.',   // description
+        '',
+        true
+    );
+}
+
+//
+// Remove all startmenu entries and the startmenu folder
+//
+async function removeStartMenu() {
+    await removeStartMenuEntry(sMenuDir, linkAdmin, iobServiceName);
+    await removeStartMenuEntry(sMenuDir, linkCmdLine, iobServiceName);
+    await removeStartMenuEntry(sMenuDir, linkStartService, iobServiceName);
+    await removeStartMenuEntry(sMenuDir, linkStopService, iobServiceName);
+    await removeStartMenuEntry(sMenuDir, linkRestartService, iobServiceName);
+    try {
+        fs.rmdirSync(sMenuDir);
+        console.log(`Startmenu folder ${sMenuDir} removed!`);
+    }
+    catch (err) {
+        if (err.code === 'ENOTEMPTY') {
+            console.log(`Startmenu folder ${sMenuDir} not removed because it is not empty!`);
+        }
+        else {
+            console.error(`Error occurred when removing startmenu folder ${sMenuDir}!`);
+            console.error(err);
+        }
+    }
+}
+
+module.exports = { createStartMenu, removeStartMenu };

--- a/install/windows/uninstall.js
+++ b/install/windows/uninstall.js
@@ -1,9 +1,13 @@
 'use strict';
 
 const Service = require('node-windows').Service;
+const Shortcuts = require('./shortcuts')
 
 // Get environment variables from file .env 
 require('dotenv').config();
+
+// Remove the according Windows startmenu entries
+Shortcuts.removeStartMenu();
 
 // Create a new service object
 const svc = new Service({

--- a/install/windows/uninstall.js
+++ b/install/windows/uninstall.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const Service = require('node-windows').Service;
-const Shortcuts = require('./shortcuts')
+const Shortcuts = require('./shortcuts');
 
 // Get environment variables from file .env 
 require('dotenv').config();

--- a/install/windows/uninstall.js
+++ b/install/windows/uninstall.js
@@ -2,9 +2,12 @@
 
 const Service = require('node-windows').Service;
 
+// Get environment variables from file .env 
+require('dotenv').config();
+
 // Create a new service object
 const svc = new Service({
-    name: 'ioBroker',
+    name: process.env.iobServiceName ? process.env.iobServiceName : 'ioBroker',
     script: require('path').join(__dirname, 'controller.js')
 });
 

--- a/lib-npx/install.js
+++ b/lib-npx/install.js
@@ -8,6 +8,7 @@ const platform = require('os').platform();
 const { execSync, exec }  = require('child_process');
 const pack = require('../package.json');
 const semver = require('semver');
+const fs = require('fs-extra');
 
 function runLinux(isFix) {
     console.log(`Linux installation starting... (fixing = ${isFix})`);
@@ -46,6 +47,15 @@ if (!/^win/.test(platform) && !tools.isAutomatedInstallation()) {
 
 } else {
     console.log(`Windows installation starting... (fixing = ${pack.name.includes('fix')})`);
+
+    // first of all we remove the file which indicates that the installation is completed
+    // this files is used to synchronise with the Windows MSI installer.
+    try {
+        fs.unlinkSync('./instDone');
+    }
+    catch(e) {
+        // nothing to do here, file did not exist
+    }
 
     // fix command for windows
     if (pack.name.includes('fix')) {

--- a/lib-npx/installSetup.js
+++ b/lib-npx/installSetup.js
@@ -164,6 +164,9 @@ function setupWindows(callback) {
             cwd: process.cwd(),
         });
 
+        // we create a file to signalize to the Windows MSI installer, that the installation process ran til the end
+        fs.createFileSync('./instDone');
+
         console.log('ioBroker service installed and started. Go to http://localhost:8081 to open the admin UI.');
         console.log('To see the outputs do not start the service, but write "node node_modules/iobroker.js-controller/controller"');
         callback && callback();

--- a/lib-npx/installSetup.js
+++ b/lib-npx/installSetup.js
@@ -78,6 +78,8 @@ const debug = !!process.env.IOB_DEBUG;
 
 function setupWindows(callback) {
     const nodeWindowsVersion = require('../package.json').optionalDependencies['node-windows'].replace(/[~^<>=]+]/g, '');
+    const dotenvVersion = require('../package.json').optionalDependencies['dotenv'].replace(/[~^<>=]+]/g, '');
+    const windowsShortcutsVersion = require('../package.json').optionalDependencies['windows-shortcuts'].replace(/[~^<>=]+]/g, '');
 
     const batExists = fs.existsSync(path.join(rootDir, 'serviceIoBroker.bat'));
     fs.writeFileSync(iobrokerRootExecutable + '.bat', commandLine.replace(/\$/g, '%'));
@@ -94,16 +96,39 @@ function setupWindows(callback) {
     // Copy the files from /install/windows to the root dir
     tools.copyFilesRecursiveSync(path.join(rootDir, 'install/windows'), rootDir);
 
-    // Call npm install node-windows
+    // Call npm install node-windows, dotenv and windows-shortcuts
     // js-controller installed as npm
     const npmRootDir = rootDir.replace(/\\/g, '/');
-    const cmd = `npm install node-windows@${nodeWindowsVersion} --force --loglevel error --production --save --prefix "${npmRootDir}"`;
+
+    let cmd = `npm install node-windows@${nodeWindowsVersion} --force --loglevel error --production --save --prefix "${npmRootDir}"`;
     console.log(cmd);
 
     try {
         execSync(cmd, {stdio: 'inherit'});
     } catch (error) {
         console.log('Error when installing Windows Service Library: ' + error);
+        callback && callback(error.code);
+        return;
+    }
+
+    cmd = `npm install dotenv@${dotenvVersion} --force --loglevel error --production --save --prefix "${npmRootDir}"`;
+    console.log(cmd);
+
+    try {
+        execSync(cmd, {stdio: 'inherit'});
+    } catch (error) {
+        console.log('Error when installing dotenv Library: ' + error);
+        callback && callback(error.code);
+        return;
+    }
+
+    cmd = `npm install windows-shortcuts@${windowsShortcutsVersion} --force --loglevel error --production --save --prefix "${npmRootDir}"`;
+    console.log(cmd);
+
+    try {
+        execSync(cmd, {stdio: 'inherit'});
+    } catch (error) {
+        console.log('Error when installing Windows Shortcuts Library: ' + error);
         callback && callback(error.code);
         return;
     }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "@iobroker/install",
   "version": "4.2.1",
   "optionalDependencies": {
-    "node-windows": "1.0.0-beta.8"
+    "node-windows": "1.0.0-beta.8",
+	"dotenv": "^16.0.3"
   },
   "publishConfig": {
     "access": "public"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "4.2.1",
   "optionalDependencies": {
     "node-windows": "1.0.0-beta.8",
-	"dotenv": "^16.0.3"
+    "dotenv": "^16.0.3",
+    "windows-shortcuts": "^0.1.6"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
This is a proposal to make the service name of the windows ioBroker service configurable.
The idea is to provide an alternative service name as environment variable. To be able to use this variable in both, bat file and node.je scripts, I chose an environment file which can be read using the dotenv library. This file can also easily be read in a batch file.
Detailed description:
To use an alternative service name, a file with the name .env must be created in the installation root directory before starting the installation. It has only one line with the following content:
`iobServiceName=<ioBroker_Service_Name>`
e.g.
`iobServiceName=ioBroker2`

In this case install.js, uninstall.js and serviceIoBroker.bat will use the given service name.
If the file does not exist or if iobServiceName is not set, the scripts will behave as before and use ioBroker as service name.

Experienced user can use this to install several instances of ioBroker on one Windows PC. Later on, this mechanism could be easily included into a Windows Installer.

This pull request includes also the removal of CLS in serviceIoBroker.bat, which makes it hard to read screen output of several procedures like e.g. npx @iobroker/fix