### PR TITLE
Windows installer: Suppress unnecessary error message

### DIFF
--- a/install/windows/setEnvIobServiceName.bat
+++ b/install/windows/setEnvIobServiceName.bat
@@ -1,5 +1,8 @@
 @echo off
+set iobServiceName=
+if exist .env (
 for /F "tokens=*" %%I in (.env) do set %%I
+)
 if not defined iobServiceName (
 	set iobServiceName=ioBroker
 )


### PR DESCRIPTION
During starting and stopping the iobroker service via batch file an unnecessary error message was displayed. Fixed.