### PR TITLE
Windows: Handle restart properly in iob.bat and iobroker.bat

### DIFF
--- a/iob.bat
+++ b/iob.bat
@@ -17,7 +17,15 @@ if [%1]==[fix] (
                     node node_modules/iobroker.js-controller/iobroker.js %1 %2 %3 %4 %5 %6 %7 %8
                 )
             ) else (
-                node node_modules/iobroker.js-controller/iobroker.js %1 %2 %3 %4 %5 %6 %7 %8
+				if [%1]==[restart] (
+					if [%2]==[] (
+						call serviceIoBroker.bat restart
+					) else (
+						node node_modules/iobroker.js-controller/iobroker.js %1 %2 %3 %4 %5 %6 %7 %8
+					)
+				) else (
+					node node_modules/iobroker.js-controller/iobroker.js %1 %2 %3 %4 %5 %6 %7 %8
+				)
             )
         )
     ) else (

--- a/iob.bat
+++ b/iob.bat
@@ -7,14 +7,14 @@ if [%1]==[fix] (
             if [%2]==[] (
                 call serviceIoBroker.bat start
             ) else (
-                node node_modules/iobroker.js-controller/iobroker.js %1 %2 %3 %4 %5 %6 %7 %8
+                node node_modules/iobroker.js-controller/iobroker.js %*
             )
         ) else (
             if [%1]==[stop] (
                 if [%2]==[] (
                     call serviceIoBroker.bat stop
                 ) else (
-                    node node_modules/iobroker.js-controller/iobroker.js %1 %2 %3 %4 %5 %6 %7 %8
+                    node node_modules/iobroker.js-controller/iobroker.js %*
                 )
             ) else (
 				if [%1]==[restart] (
@@ -24,11 +24,11 @@ if [%1]==[fix] (
 						node node_modules/iobroker.js-controller/iobroker.js %*
 					)
 				) else (
-					node node_modules/iobroker.js-controller/iobroker.js %1 %2 %3 %4 %5 %6 %7 %8
+					node node_modules/iobroker.js-controller/iobroker.js %*
 				)
             )
         )
     ) else (
-        node node_modules/iobroker.js-controller/iobroker.js %1 %2 %3 %4 %5 %6 %7 %8
+        node node_modules/iobroker.js-controller/iobroker.js %*
     )
 )

--- a/iob.bat
+++ b/iob.bat
@@ -21,7 +21,7 @@ if [%1]==[fix] (
 					if [%2]==[] (
 						call serviceIoBroker.bat restart
 					) else (
-						node node_modules/iobroker.js-controller/iobroker.js %1 %2 %3 %4 %5 %6 %7 %8
+						node node_modules/iobroker.js-controller/iobroker.js %*
 					)
 				) else (
 					node node_modules/iobroker.js-controller/iobroker.js %1 %2 %3 %4 %5 %6 %7 %8

--- a/iobroker.bat
+++ b/iobroker.bat
@@ -1,26 +1,2 @@
 @echo off
-if [%1]==[fix] (
-    npx @iobroker/fix
-) else (
-    if exist serviceIoBroker.bat (
-        if [%1]==[start] (
-            if [%2]==[] (
-                call serviceIoBroker.bat start
-            ) else (
-                node node_modules/iobroker.js-controller/iobroker.js %1 %2 %3 %4 %5 %6 %7 %8
-            )
-        ) else (
-            if [%1]==[stop] (
-                if [%2]==[] (
-                    call serviceIoBroker.bat stop
-                ) else (
-                    node node_modules/iobroker.js-controller/iobroker.js %1 %2 %3 %4 %5 %6 %7 %8
-                )
-            ) else (
-                node node_modules/iobroker.js-controller/iobroker.js %1 %2 %3 %4 %5 %6 %7 %8
-            )
-        )
-    ) else (
-        node node_modules/iobroker.js-controller/iobroker.js %1 %2 %3 %4 %5 %6 %7 %8
-    )
-)
+iob.bat %1 %2 %3 %4 %5 %6 %7 %8

--- a/iobroker.bat
+++ b/iobroker.bat
@@ -1,2 +1,2 @@
 @echo off
-iob.bat %1 %2 %3 %4 %5 %6 %7 %8
+call iob.bat %1 %2 %3 %4 %5 %6 %7 %8


### PR DESCRIPTION
The commands start and stop were already forwarded to the batch file serviceIoBroker.bat.
Restart was not forwarded to serviceIoBroker.bat but to "node node_modules/iobroker.js-controller/iobroker.js restart".
"iobroker.js" does (currently?) not work properly under Windows, I guess this is the reason why  "serviceIoBroker.bat restart" stops and starts the windows service instead of calling iobroker.js.
Now also restart is also forwarded to  serviceIoBroker.bat
With this fix restart of the ioBroker Controller in the Admin adapter does work as expected again.
Without this fix, ioBroker is restarted, but the Windows service is stopped.