### PR TITLE
favicon has moved

### DIFF
--- a/install/windows/shortcuts.js
+++ b/install/windows/shortcuts.js
@@ -101,7 +101,7 @@ const linkAdmin = 'ioBroker Admin.lnk';
 const linkStartService = 'Start ioBroker Service.lnk';
 const linkStopService = 'Stop ioBroker Service.lnk';
 const linkRestartService = 'Restart ioBroker Service.lnk';
-const iconPath = path.join(process.cwd(), '\\node_modules\\iobroker.admin\\www\\favicon.ico');
+const iconPath = path.join(process.cwd(), '\\node_modules\\iobroker.admin\\adminWww\\favicon.ico');
 const servicePath = path.join(process.cwd(), 'serviceiobroker.bat');
 
 //


### PR DESCRIPTION
1. alternative is we ship an icon with installer and place it somewhere
2. or admin moves it back to `www` but `www` is uploaded which is not needed for admin

In the long term I would prefer 1. as it does not rely on other adapters structure, the question would just be where to place it, maybe a separate folder or single icon in the data folder