### PR TITLE
Add 'iobroker' to 'plugdev' group

### DIFF
--- a/installer_library.sh
+++ b/installer_library.sh
@@ -684,6 +684,7 @@ create_user_linux() {
 		dialout
 		gpio
 		i2c
+  		plugdev
 		redis
 		tty
 		video
@@ -750,6 +751,7 @@ create_user_freebsd() {
 		dialout
 		gpio
 		i2c
+  		plugdev
 		redis
 		tty
 		video


### PR DESCRIPTION
Add 'iobroker' to 'plugdev' group
Some USB Serialdevices are set up like this. 
See https://forum.iobroker.net/topic/74091/vedirect-keine-verbindung-bei-rasp-4/20?_=1713105842096