### PR TITLE
Preparation for JS-Controller 6

### DIFF
--- a/install/windows/controller.js
+++ b/install/windows/controller.js
@@ -1,2 +1,2 @@
 'use strict';
-require('./node_modules/iobroker.js-controller/controller.js');
+import('./node_modules/iobroker.js-controller/controller.js');


### PR DESCRIPTION
Use import instead of require because controller.js runs as ES module starting vith version 6.x. Import works also with older versions of controller.js.