### PR TITLE
Modify redis locale if used by ioBroker

### DIFF
--- a/fix_installation.sh
+++ b/fix_installation.sh
@@ -27,6 +27,7 @@ set_valid_redis_locale() {
         # Check if the redis service file contains the LC_ALL setting
         if ! grep -q "Environment" "/lib/systemd/system/redis-server.service"; then
           sed -i '/\[Service\]/a Environment="LC_ALL=C"' /lib/systemd/system/redis-server.service
+          $SUDOX systemctl restart redis-server
         fi
       fi
     fi

--- a/fix_installation.sh
+++ b/fix_installation.sh
@@ -19,6 +19,19 @@ compress_jsonl_databases() {
     fi;
 }
 
+set_valid_redis_locale() {
+    # Check if redis installed
+    if [ -f "/lib/systemd/system/redis-server.service" ]; then
+      # Check if the redis used by iobroker
+      if grep -q "\"type\": \"redis\"" "$IOB_DIR/iobroker-data/iobroker.json"; then
+        # Check if the redis service file contains the LC_ALL setting
+        if ! grep -q "Environment" "/lib/systemd/system/redis-server.service"; then
+          sed -i '/\[Service\]/a Environment="LC_ALL=C"' /lib/systemd/system/redis-server.service
+        fi
+      fi
+    fi
+}
+
 # Test if this script is being run as root or not
 if [[ $EUID -eq 0 ]];
 then IS_ROOT=true;  SUDOX=""
@@ -43,15 +56,15 @@ LIB_NAME="installer_library.sh"
 LIB_URL="https://raw.githubusercontent.com/ioBroker/ioBroker/master/$LIB_NAME"
 # get and load the LIB
 curl -sL $LIB_URL > ~/$LIB_NAME
-if test -f ~/$LIB_NAME; then source ~/$LIB_NAME; else echo "Installer/Fixer: library not found"; exit -2; fi
+if test -f ~/$LIB_NAME; then source ~/$LIB_NAME; else echo "Installer/Fixer: library not found"; exit 2; fi
 # Delete the lib again. We have sourced it so we don't need it anymore
 rm ~/$LIB_NAME
 # get and load the LIB => END
 
 # test one function of the library
 RET=$(get_lib_version)
-if [ $? -ne 0 ]; then echo "Installer/Fixer: library $LIB_NAME could not be loaded!"; exit -2; fi
-if [ "$RET" == "" ]; then echo "Installer/Fixer: library $LIB_NAME does not work."; exit -2; fi
+if [ $? -ne 0 ]; then echo "Installer/Fixer: library $LIB_NAME could not be loaded!"; exit 3; fi
+if [ "$RET" == "" ]; then echo "Installer/Fixer: library $LIB_NAME does not work."; exit 4; fi
 echo "Library version=$RET"
 
 
@@ -287,6 +300,9 @@ make_executable "$IOB_DIR/iobroker"
 # and give them the correct ownership
 change_owner $IOB_USER "$IOB_DIR/iobroker"
 change_owner $IOB_USER "$IOB_DIR/iob"
+
+# Modify redis locale if used by ioBroker
+set_valid_redis_locale
 
 # Enable autostart
 if [[ "$INITSYSTEM" = "init.d" ]]; then

--- a/installer.sh
+++ b/installer.sh
@@ -28,15 +28,15 @@ fi;
 LIB_NAME="installer_library.sh"
 LIB_URL="https://raw.githubusercontent.com/ioBroker/ioBroker/master/$LIB_NAME"
 curl -sL $LIB_URL > ~/$LIB_NAME
-if test -f ~/$LIB_NAME; then source ~/$LIB_NAME; else echo "Installer/Fixer: library not found"; exit -2; fi
+if test -f ~/$LIB_NAME; then source ~/$LIB_NAME; else echo "Installer/Fixer: library not found"; exit 2; fi
 # Delete the lib again. We have sourced it so we don't need it anymore
 rm ~/$LIB_NAME
 # get and load the LIB => END
 
 # test one function of the library
 RET=$(get_lib_version)
-if [ $? -ne 0 ]; then echo "Installer/Fixer: library $LIB_NAME could not be loaded!"; exit -2; fi
-if [ "$RET" == "" ]; then echo "Installer/Fixer: library $LIB_NAME does not work."; exit -2; fi
+if [ $? -ne 0 ]; then echo "Installer/Fixer: library $LIB_NAME could not be loaded!"; exit 3; fi
+if [ "$RET" == "" ]; then echo "Installer/Fixer: library $LIB_NAME does not work."; exit 4; fi
 echo "Library version=$RET"
 
 # Test which platform this script is being run on
@@ -490,7 +490,7 @@ else
 	echo "Autostart: false" >> "$INSTALLER_INFO_FILE"
 fi
 
-# Raspbery image has as last line in /etc/rc.local the ioBroker installer. It must be removed
+# Raspberry image has as last line in /etc/rc.local the ioBroker installer. It must be removed
 if [ -f /etc/rc.local ]; then
 	if [ -w /etc/rc.local ]; then
 		if [ "$IS_ROOT" != true ]; then


### PR DESCRIPTION
For any new installations with redis I see following message:
![image](https://github.com/user-attachments/assets/759fc19b-f006-4a16-9c1b-61a12727b5af)

Even with not ended wizard process. That is not good for user experience. At least with this modification the user can call:
`iob fix`
to fix the problem at least by systems with systemd