### PR TITLE
Update installer.sh - require node.js 18 minimum

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -155,7 +155,7 @@ PACKAGE_JSON_FILE=$(cat <<- EOF
 		"private": true,
 		"description": "Automate your Life",
 		"engines": {
-			"node": ">=16.0.0"
+			"node": ">=18.0.0"
 		},
 		"dependencies": {
 			"iobroker.js-controller": "stable",


### PR DESCRIPTION
As ioBroker requires node.js 18 in the meantime package.json created during installation should no longer require node 16 only.

@Apollon77 
@foxriver76 

Please recheck / merge