### PR TITLE
Fixed release name detection

### DIFF
--- a/CHANGELOG_DIAG_LINUX.md
+++ b/CHANGELOG_DIAG_LINUX.md
@@ -1,5 +1,9 @@
 # Changelog for Linux-Diag-Script
 
+## 2025-08-09
+Added nodejs vulnerability check
+Removed references to static release names 
+
 ## 2025-05-24
 * Added test for Xorg Display Server
 * Only show zigbee settings when zigbee-Adapter is installed 

--- a/diag.sh
+++ b/diag.sh
@@ -152,7 +152,7 @@ if [ -f "$DOCKER" ]; then
     echo -e "Userland        : $(getconf LONG_BIT) bit"
     echo -e "Docker          : $(cat /opt/scripts/.docker_config/.thisisdocker)"
 else
-    hostnamectl | grep -v 'Machine\|Boot'
+    hostnamectl | grep -v 'Machine\|Boot\|Operating'
     echo "OS is similar to: $ID_LIKE"
     echo ""
     grep -i model /proc/cpuinfo | tail -1


### PR DESCRIPTION
Fixed release name detection - Some files containing this information were static so they did not reflect in-line-Upgrades from old-stable to stable. 