### PR TITLE
Fixed removal of nodejs, including dfsg version now

### DIFF
--- a/CHANGELOG_NODE_UPDATER.md
+++ b/CHANGELOG_NODE_UPDATER.md
@@ -1,5 +1,8 @@
 # Changelog for Node.js Updater Script
 
+## 2026-03-05
+* Make sure any previously installed nodejs is removed, including dfsg version
+
 ## 2026-03-02
 * Use deb822 format for sources in accordance with nodesource installer script
 * Replace hardcoded Node.js version with dynamic lookup from `versions.json`

--- a/node-update.sh
+++ b/node-update.sh
@@ -3,7 +3,7 @@
 # written to help updating and fixing nodejs on linux (Debian based Distros)
 
 #To be manually changed:
-VERSION="2026-03-02"
+VERSION="2026-03-05"
 
 # Load recommended Node.js version from versions.json (fallback to 22 if not reachable)
 VERSIONS_URL="https://raw.githubusercontent.com/ioBroker/ioBroker/master/versions.json"
@@ -189,7 +189,7 @@ then
     exit
 fi
 
-DFSGREM="$SUDOX $INSTALL_CMD remove libnode* node-* nodejs-doc npm -qqy" #Deinstall DFSG-Version
+DFSGREM="$SUDOX $INSTALL_CMD remove libnode* node-* nodejs-doc npm nodejs -qqy" #Deinstall DFSG-Version
 
 clear
 echo -e "ioBroker nodejs fixer $VERSION"
@@ -281,25 +281,25 @@ then
             [[ -f /usr/bin/nodejs && "$PATHNODEJS" != "/usr/bin/nodejs" ]]
         then
             echo -e "*** Deleting $PATHNODEJS ***"
-            $SUDOX rm "$(type -p nodejs)"
+            $SUDOX rm "$(type -p nodejs)" >/dev/null 2>&1
         fi
         if
             [[ "$PATHNODE" != "/usr/bin/node" ]]
         then
             echo -e "*** Deleting $PATHNODE ***"
-            $SUDOX rm "$(type -p node)"
+            $SUDOX rm "$(type -p node)" >/dev/null 2>&1
         fi
         if
             [[ "$PATHNPM" != "/usr/bin/npm" ]]
         then
             echo -e "*** Deleting $PATHNPM ***"
-            $SUDOX rm "$(type -p npm)"
+            $SUDOX rm "$(type -p npm)" >/dev/null 2>&1
         fi
         if
             [[ "$PATHNPX" != "/usr/bin/npx" ]]
         then
             echo -e "*** Deleting $PATHNPX ***"
-            $SUDOX rm "$(type -p npx)"
+            $SUDOX rm "$(type -p npx)" >/dev/null 2>&1
         fi
         echo -e "\nWrong paths have been fixed. Run 'iob diag' or 'iob nodejs-update' again to check if your installation is fine now"
     fi
@@ -423,7 +423,7 @@ fi
 
 echo ""
 echo ""
-echo "Removing dfsg-nodejs"
+echo "Removing any previously installed nodejs version"
 eval "$DFSGREM"
 echo ""
 

--- a/node-update.sh
+++ b/node-update.sh
@@ -189,7 +189,7 @@ then
     exit
 fi
 
-DFSGREM="$SUDOX $INSTALL_CMD remove libnode* node-* nodejs-doc npm nodejs -qqy" #Deinstall DFSG-Version
+DFSGREM="$SUDOX $INSTALL_CMD remove libnode* node-* nodejs-doc npm nodejs -qqy" # Remove distro-packaged Node.js and related packages
 
 clear
 echo -e "ioBroker nodejs fixer $VERSION"


### PR DESCRIPTION
Any non-nodesource nodejs installation is now removed, including the dfsg version.