### PR TITLE
CI: actually test the library from the branch, not from master

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -5,15 +5,15 @@ task:
   prepare_install_script:
     - pkg install -y bash node npm libnghttp2 python sudo
   install_script:
-    # remove download of library from installer script and fixer and source it manually
-    - |
-      sed '/# get and load the LIB => START/,/# get and load the LIB => END/d' installer.sh
-      sed '/# get and load the LIB => START/,/# get and load the LIB => END/d' fix_installation.sh
-      source ./installer_library.sh
+    # installer.sh and fix_installation.sh download installer_library.sh from master at
+    # runtime. The previous sed/source pair never changed that: sed without -i writes to
+    # stdout and the sourced functions were gone by the next command. Build the
+    # self-contained scripts instead, so this branch's library is the one under test.
+    - node tasks --create
     # Install ioBroker
     - |
-      sudo chmod +x ./installer.sh
-      ./installer.sh
+      sudo chmod +x ./dist/install.sh
+      ./dist/install.sh
   test_script:
     # Test file permissions
     - |
@@ -33,10 +33,11 @@ task:
     - node node_modules/iobroker.js-controller/iobroker.js stop
     - sleep 60
     #
-    - cd $TEST_DIR
+    # $TEST_DIR was never defined, so this was a bare "cd" into $HOME
+    - cd $CIRRUS_WORKING_DIR
     # Run the fixer
-    - sudo chmod +x ./fix_installation.sh
-    - sudo env "PATH=$PATH" bash ./fix_installation.sh
+    - sudo chmod +x ./dist/fix.sh
+    - sudo env "PATH=$PATH" bash ./dist/fix.sh
     # Test file permissions again...
     - sudo chmod +x .github/testFiles.sh
     - bash .github/testFiles.sh

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -20,8 +20,18 @@ task:
       sudo chmod +x .github/testFiles.sh
       .github/testFiles.sh
 
-    # Test if ioBroker starts by checking the admin adapter output
-    - curl --insecure http://127.0.0.1:8081 2> /dev/null | grep '<title>Admin</title>' &> /dev/null || exit 1
+    # Test if ioBroker starts by checking the admin adapter output.
+    # Retry, the service needs a while to come up.
+    - |
+      for i in $(seq 1 36); do
+        if curl -s --insecure http://127.0.0.1:8081 | grep -q '<title>Admin</title>'; then
+          echo "admin is reachable after $((i * 5))s"
+          exit 0
+        fi
+        sleep 5
+      done
+      echo "admin did not become reachable within 180s"
+      exit 1
 
     # Now test if adapters which require python can be installed
     - iobroker url iobroker.lovelace

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,30 +20,33 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x, 24.x]
+        # No node-version matrix on purpose: there was no actions/setup-node step, so the
+        # four entries produced four identical jobs. The installer selects and installs its
+        # own Node.js version anyway, which is what this job is supposed to exercise.
         os: [ubuntu-latest, macos-latest]
 
     steps:
     - name: Checkout code
       uses: actions/checkout@v7
 
-    - name: Fix up installer script for local installs
-      run: |
-        # remove download of library
-        sed '/# get and load the LIB => START/,/# get and load the LIB => END/d' installer.sh
-        # and source it manually
-        source ./installer_library.sh
+    # installer.sh downloads installer_library.sh from master at runtime, so running it
+    # directly would test master's library instead of the one in this branch. The previous
+    # attempt to strip that block had no effect: sed without -i writes to stdout, and the
+    # sourced functions were gone by the next step anyway.
+    # "node tasks --create" inlines the local library into dist/install.sh, which is also
+    # the artifact that gets deployed to iobroker.net.
+    - name: Build the self-contained installer
+      run: node tasks --create
 
     - name: Install ioBroker
-      run: bash ./installer.sh --silent
+      run: bash ./dist/install.sh --silent
 
     - name: Test permissions
       # TODO: test this on OSX too!
-      if: startsWith(runner.OS, 'ubuntu')
+      # runner.os is 'Linux', never 'ubuntu', so the previous startsWith() condition was
+      # always false and this step never ran on any runner.
+      if: runner.os == 'Linux'
       run: bash .github/testFiles.sh
-
-    - name: Prepare tests
-      run: npm install mocha chai
 
     - name: Test if ioBroker starts by checking the admin adapter output
       run: curl --insecure http://127.0.0.1:8081 2> /dev/null | grep '<title>Admin</title>' &> /dev/null || exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,5 +48,17 @@ jobs:
       if: runner.os == 'Linux'
       run: bash .github/testFiles.sh
 
+    # The service needs a while to come up. This used to be a single attempt that only
+    # worked because an unrelated "npm install mocha chai" step ran before it and acted
+    # as an accidental delay - a race, not a test. Retry instead.
     - name: Test if ioBroker starts by checking the admin adapter output
-      run: curl --insecure http://127.0.0.1:8081 2> /dev/null | grep '<title>Admin</title>' &> /dev/null || exit 1
+      run: |
+        for i in $(seq 1 36); do
+          if curl -s --insecure http://127.0.0.1:8081 | grep -q '<title>Admin</title>'; then
+            echo "admin is reachable after $((i * 5))s"
+            exit 0
+          fi
+          sleep 5
+        done
+        echo "admin did not become reachable within 180s"
+        exit 1

--- a/tasks.js
+++ b/tasks.js
@@ -1,6 +1,5 @@
 const { readFileSync, writeFileSync, existsSync, mkdirSync } = require('node:fs');
 const Stream = require('node:stream');
-const { Client } = require('ssh2');
 
 const dist = `${__dirname}/dist/`;
 
@@ -48,6 +47,10 @@ function writeSftp(sftp, fileName, data, cb) {
 }
 
 function uploadOneFile(fileName, data) {
+    // Required lazily: only the deploy path needs ssh2, so "node tasks --create"
+    // works in a fresh checkout without installing the dev dependencies.
+    const { Client } = require('ssh2');
+
     return new Promise((resolve, reject) => {
         const conn = new Client();
         conn.on('ready', () =>


### PR DESCRIPTION
Independent of #740, and touching only CI configuration plus `tasks.js`.

## The blind spot

`installer.sh` and `fix_installation.sh` fetch `installer_library.sh` from `master` at runtime. Both CI configs tried to remove that block first:

```bash
sed '/# get and load the LIB => START/,/# get and load the LIB => END/d' installer.sh
source ./installer_library.sh
```

Neither line does anything useful. `sed` without `-i` writes to stdout and leaves the file untouched, and the sourced functions are gone by the time the next step (or next Cirrus command) runs its own shell. Every CI run therefore installed using **master's** library.

The practical consequence: a PR that changes only `installer_library.sh` gets a green check that executed none of its changes. That is roughly a third of the Linux/macOS installer logic — user creation, package installation, Node.js installation, permissions, Redis.

## The fix

Both configs now build the self-contained scripts and run those:

```yaml
- name: Build the self-contained installer
  run: node tasks --create

- name: Install ioBroker
  run: bash ./dist/install.sh --silent
```

This is the same artifact that `npm run deploy` uploads to iobroker.net, so CI now tests what users actually get, and it covers `tasks.js` itself along the way.

Verified locally with a canary — marking the local library and rebuilding:

```
$ sed -i 's/^LIBRARY_VERSION="/LIBRARY_VERSION="CANARY-/' installer_library.sh
$ node tasks --create
$ grep -o 'LIBRARY_VERSION="CANARY-[^"]*"' dist/install.sh
LIBRARY_VERSION="CANARY-2026-04-11"
```

`dist/install.sh` contains no `LIB_URL` and no `raw.githubusercontent.com` reference any more, and all four generated scripts pass `bash -n`.

## `tasks.js`: lazy `require('ssh2')`

`node tasks --create` used to fail in a fresh checkout with `Error: Cannot find module 'ssh2'`, because the require sat at the top level even though only the deploy path uses it. Moved into `uploadOneFile`, so CI can build the artifact without `npm install`. The deploy path is unchanged.

## Three more dead pieces of CI, found while fixing the above

* **`.cirrus.yml`: `$TEST_DIR` was never defined.** `cd $TEST_DIR` was therefore a bare `cd` into `$HOME`, and the whole fixer half of the FreeBSD test ran in the wrong directory. Now `$CIRRUS_WORKING_DIR`.
* **`test.yml`: the permission test never ran.** It was guarded by `if: startsWith(runner.OS, 'ubuntu')`, but `runner.os` is `Linux`, never `ubuntu`, so the condition was always false on every runner. Now `if: runner.os == 'Linux'`.
* **`test.yml`: the `node-version` matrix did nothing.** There is no `actions/setup-node` step, so `[18.x, 20.x, 22.x, 24.x]` produced four *identical* jobs per OS — eight full 6-10 minute installs where two would do. Removed, since the installer selects and installs its own Node.js version anyway, which is precisely what this job exercises. If you want genuine multi-version coverage, that needs `actions/setup-node` plus a check that the installer copes with a pre-seeded Node.js in the tool cache; happy to do that as a follow-up rather than smuggle it in here.
* **`test.yml`: dropped the `Prepare tests` step.** It ran `npm install mocha chai`; nothing in this repository uses either.

## What to expect on the first run

Enabling the permission test means `.github/testFiles.sh` executes for the first time. If it reports ownership or permission problems, those are pre-existing and were simply never surfaced — worth looking at rather than re-disabling.

No script version bumps or changelog entries: no shell script logic changed, and `tasks.js` is build tooling that is not part of the published package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M4gDpoBsbSDNye88UpSWPm
