### PR TITLE
CI: make the Node.js version matrix real and derive it from versions.json

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,22 +12,58 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Derive the test matrix from versions.json, the same source of truth the installer,
+  # the NPX package and ioBroker.admin read. A version added or dropped there is then
+  # picked up here automatically instead of drifting apart.
+  node-versions:
+    if: contains(github.event.head_commit.message, '[skip ci]') == false
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.read.outputs.matrix }}
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v7
+
+    - name: Read nodeJsAccepted from versions.json
+      id: read
+      run: |
+        MATRIX=$(jq -c '[.nodeJsAccepted[] | tostring + ".x"]' versions.json)
+        echo "Testing against Node.js: $MATRIX"
+        echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
+
   # ===================
   # Runs unit tests on all supported node versions and OSes
   test-install:
+    needs: node-versions
     if: contains(github.event.head_commit.message, '[skip ci]') == false
 
     runs-on: ${{ matrix.os }}
     strategy:
+      # One unsupported version should not hide the result for the others
+      fail-fast: false
       matrix:
-        # No node-version matrix on purpose: there was no actions/setup-node step, so the
-        # four entries produced four identical jobs. The installer selects and installs its
-        # own Node.js version anyway, which is what this job is supposed to exercise.
+        node-version: ${{ fromJson(needs.node-versions.outputs.matrix) }}
         os: [ubuntu-latest, macos-latest]
 
     steps:
     - name: Checkout code
       uses: actions/checkout@v7
+
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v7
+      with:
+        node-version: ${{ matrix.node-version }}
+
+    # setup-node only prepends the tool cache to PATH for the steps that follow. The
+    # generated systemd unit resolves its interpreter with "which node" at service start,
+    # using systemd's own PATH, which never contains the tool cache. Without this link the
+    # matrix would only change the Node.js that the install script sees, while ioBroker
+    # itself would keep running on the image's default version.
+    - name: Make the selected Node.js the system Node.js
+      run: |
+        sudo ln -sf "$(command -v node)" /usr/local/bin/node
+        sudo ln -sf "$(command -v npm)" /usr/local/bin/npm
+        /usr/local/bin/node -v
 
     # installer.sh downloads installer_library.sh from master at runtime, so running it
     # directly would test master's library instead of the one in this branch. The previous
@@ -62,3 +98,16 @@ jobs:
         done
         echo "admin did not become reachable within 180s"
         exit 1
+
+    # Guard so the matrix cannot quietly go back to being decorative: resolve "node" the
+    # way systemd does when it starts the unit and compare it against the matrix entry.
+    - name: Verify the service resolves Node.js ${{ matrix.node-version }}
+      if: runner.os == 'Linux'
+      run: |
+        expected="${{ matrix.node-version }}"
+        expected="${expected%.x}"
+        actual=$(sudo env -i PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin node -v)
+        actual="${actual#v}"
+        actual="${actual%%.*}"
+        echo "ioBroker would start on Node.js $actual, the matrix asks for $expected"
+        test "$actual" = "$expected"


### PR DESCRIPTION
Follow-up to #741, which removed the `node-version` matrix because there was no `actions/setup-node` step behind it. **Stacked on #741** — the base is that branch, so the diff here shows only the incremental change. GitHub retargets this to `master` automatically once #741 is merged.

## Adding setup-node alone would not have worked

That was my assumption when I offered this follow-up in #741, and it turned out to be wrong. `actions/setup-node` only prepends the tool cache to `PATH` via `GITHUB_PATH`, which affects the steps that follow. But the generated systemd unit is:

```ini
Environment="NODE=$(which node)"
ExecStart=/bin/bash -c '${NODE} /opt/iobroker/node_modules/iobroker.js-controller/controller.js'
```

systemd expands `${NODE}` into the command line, bash then performs the substitution — so `which node` runs at **service start**, resolved against **systemd's** `PATH` (`/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin`). The tool cache is never in it.

So a plain `setup-node` would have changed the Node.js that the *install script* sees, while ioBroker itself kept running on the image's default version. The matrix would have looked like multi-version coverage without being any.

Two steps fix that:

```yaml
- name: Make the selected Node.js the system Node.js
  run: |
    sudo ln -sf "$(command -v node)" /usr/local/bin/node
    sudo ln -sf "$(command -v npm)" /usr/local/bin/npm
```

and a guard at the end that resolves `node` exactly the way systemd will and compares it against the matrix entry:

```yaml
actual=$(sudo env -i PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin node -v)
test "$actual_major" = "$expected_major"
```

Verified locally:

```
matrix=20.x  node -v=v20.18.1  -> expected 20  actual 20  PASS
matrix=22.x  node -v=v22.11.0  -> expected 22  actual 22  PASS
matrix=24.x  node -v=v24.3.0   -> expected 24  actual 24  PASS
matrix=26.x  node -v=v26.0.0   -> expected 26  actual 26  PASS
matrix=22.x  node -v=v20.18.1  -> expected 22  actual 20  FAIL   <- the guard bites
```

Without that guard this whole class of "the matrix does nothing" bug just comes back the next time something moves.

## The matrix follows versions.json

A small first job reads `nodeJsAccepted` and hands the list to the matrix:

```yaml
MATRIX=$(jq -c '[.nodeJsAccepted[] | tostring + ".x"]' versions.json)
```

Same source of truth as the installer, the NPX package and ioBroker.admin, so adding or dropping a supported version no longer needs a separate CI edit. Checked against both shapes of the file:

```
{"nodeJsAccepted":[18,20,22,24]}  ->  ["18.x","20.x","22.x","24.x"]
{"nodeJsAccepted":[20,22,24,26]}  ->  ["20.x","22.x","24.x","26.x"]
```

`fail-fast: false` so one unsupported version does not hide the result for the others.

## Something worth a separate look

While working this out I noticed `installer.sh:120`:

```bash
# Install Node.js if it is not installed
if [[ $(type -P "node" 2>/dev/null) != *"/node" ]]; then
    install_nodejs
fi
```

The installer only checks whether `node` **exists**, never which version it is. Two consequences:

1. GitHub and Cirrus runners ship with Node.js preinstalled, so `install_nodejs` has never run in CI. The whole NodeSource path — GPG key import, `nodesource.sources`, apt pinning — is untested, on every platform.
2. On a real machine with an unsupported Node.js already present, the installer will happily install ioBroker on top of it. With 18 dropped from `nodeJsAccepted`, `installer.sh` still accepts it silently.

Both are pre-existing and out of scope here. Happy to take either on if you want it — (2) is a change to `installer.sh` and belongs with the version-alignment work in #740 rather than in a CI pull request.

## What to expect on the first run

If Node.js 26 is not yet in the setup-node manifest, that job will fail on the setup step; the fix is to drop 26 from `nodeJsAccepted` or to wait for the manifest, not to pin the matrix by hand — that would reintroduce the drift this PR removes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M4gDpoBsbSDNye88UpSWPm
