### PR TITLE
Encode the update subcommand in INSTALL_CMD_UPD_ARGS (reimplements #703)

### DIFF
--- a/CHANGELOG_FIXER_LINUX.md
+++ b/CHANGELOG_FIXER_LINUX.md
@@ -2,6 +2,7 @@
 
 ## 2026-09-06
 * Corrected the version stamp, which was left at 2025-09-18 when the script was last changed
+* Moved the update subcommand into INSTALL_CMD_UPD_ARGS and removed the duplicated package manager branches
 
 ## 2026-03-02
 * Detect `dnf` on modern Fedora/RPM-based distros and use `makecache` instead of `update` to refresh package metadata without upgrading all packages

--- a/CHANGELOG_INSTALLER_LINUX.md
+++ b/CHANGELOG_INSTALLER_LINUX.md
@@ -4,6 +4,7 @@
 * Fixed the timezone check for 'Etc/UTC' which never triggered due to a typo
 * Replace an installed Node.js version that is not listed in nodeJsAccepted instead of only checking that node exists
 * Dropped Node.js 18 and 20 from the accepted versions, iobroker.admin requires Node.js 22 or newer
+* Moved the update subcommand into INSTALL_CMD_UPD_ARGS and removed the duplicated package manager branches
 
 ## 2026-04-11
 * Muted some confusing error messages.

--- a/fix_installation.sh
+++ b/fix_installation.sh
@@ -181,11 +181,7 @@ print_step "Installing prerequisites" 1 "$NUM_STEPS"
 if [ "$SKIP_UPDATE" = true ]; then
     echo "Skipping system package repository update (--no-update flag specified)"
 else
-    if [ "$INSTALL_CMD" = "yum" ] || [ "$INSTALL_CMD" = "dnf" ]; then
-        $SUDOX $INSTALL_CMD $INSTALL_CMD_UPD_ARGS makecache
-    else
-        $SUDOX $INSTALL_CMD $INSTALL_CMD_UPD_ARGS update
-    fi
+    $SUDOX $INSTALL_CMD $INSTALL_CMD_UPD_ARGS
 fi
 
 # Determine the platform we operate on and select the installation routine/packages accordingly

--- a/installer.sh
+++ b/installer.sh
@@ -110,11 +110,7 @@ fi
 print_step "Installing prerequisites" 1 "$NUM_STEPS"
 
 # update repos
-if [ "$INSTALL_CMD" = "yum" ] || [ "$INSTALL_CMD" = "dnf" ]; then
-    $SUDOX $INSTALL_CMD $INSTALL_CMD_UPD_ARGS makecache
-else
-    $SUDOX $INSTALL_CMD $INSTALL_CMD_UPD_ARGS update
-fi
+$SUDOX $INSTALL_CMD $INSTALL_CMD_UPD_ARGS
 
 # Install Node.js if it is not installed, or if the installed version is not supported.
 # Checking only whether "node" exists let ioBroker be installed on any version,

--- a/installer_library.sh
+++ b/installer_library.sh
@@ -102,11 +102,12 @@ get_platform_params() {
     # HOST_PLATFORM:    Name of the platform
     # INSTALL_CMD:      Command for package installation
     # INSTALL_CMD_ARGS: Arguments for $INSTALL_CMD to install something
-    # INSTALL_CMD_UPD_ARGS: Arguments for $INSTALL_CMD to update something
+    # INSTALL_CMD_UPD_ARGS: Subcommand and arguments for $INSTALL_CMD to refresh the
+    #                   package metadata, so callers do not have to branch per manager
     # IOB_DIR:          Directory where iobroker should be installed
     # IOB_USER:          The user to run ioBroker as
 
-    INSTALL_CMD_UPD_ARGS=""
+    INSTALL_CMD_UPD_ARGS="update"
 
     unamestr=$(uname)
     case "$unamestr" in
@@ -118,12 +119,12 @@ get_platform_params() {
             INSTALL_CMD="dnf"
             # The args -y and -q have to be separate
             INSTALL_CMD_ARGS="install -q -y"
-            INSTALL_CMD_UPD_ARGS="-y"
+            INSTALL_CMD_UPD_ARGS="-y makecache"
         elif [[ $(which "yum" 2>/dev/null) == *"/yum" ]]; then
             INSTALL_CMD="yum"
             # The args -y and -q have to be separate
             INSTALL_CMD_ARGS="install -q -y"
-            INSTALL_CMD_UPD_ARGS="-y"
+            INSTALL_CMD_UPD_ARGS="-y makecache"
         fi
         IOB_DIR="/opt/iobroker"
         IOB_USER="iobroker"
@@ -847,13 +848,8 @@ install_nodejs() {
     print_bold "Installing Node.js $NODE_MAJOR..."
 
     if [ "$INSTALL_CMD" = "yum" ] || [ "$INSTALL_CMD" = "dnf" ]; then
-        if [ "$INSTALL_CMD" = "yum" ]; then
-            $SUDOX rm -f /etc/yum.repos.d/nodesource*.repo
-            REPO_DIR="/etc/yum.repos.d"
-        else
-            $SUDOX rm -f /etc/yum.repos.d/nodesource*.repo
-            REPO_DIR="/etc/yum.repos.d"
-        fi
+        $SUDOX rm -f /etc/yum.repos.d/nodesource*.repo
+        REPO_DIR="/etc/yum.repos.d"
         SYS_ARCH=$(uname -m)
         NODEJS_REPO_CONTENT="[nodesource-nodejs]
 name=Node.js Packages for Linux RPM based distros - $SYS_ARCH


### PR DESCRIPTION
Reimplementation of #703 on the current tree. **Stacked on #740** — that branch already moves the same version stamps and changelog headings, so rebasing #703 would have meant resolving those conflicts twice.

Original work by Copilot, from review comments by @raintonr on #654.

## The analysis

The refactor is correct. `INSTALL_CMD_UPD_ARGS` gains the subcommand (`update` by default, `-y makecache` for yum/dnf) so the two call sites stop branching on the package manager. I checked all four uses in the tree — the two in `installer.sh` and `fix_installation.sh` are the only consumers, nothing else reads the variable.

Verified by sourcing the real `get_platform_params` from master and from this branch and comparing the command each one produces:

| platform | master | after |
| --- | --- | --- |
| Linux / apt | `apt-get update` | `apt-get update` |
| Linux / dnf | `dnf -y makecache` | `dnf -y makecache` |
| Linux / yum | `yum -y makecache` | `yum -y makecache` |
| Darwin / brew | `brew update` | `brew update` |
| FreeBSD / pkg | `pkg update` | `pkg update` |

Identical everywhere, including the `brew` and `pkg` paths that the pull request description does not mention — they previously relied on the empty default plus the caller's `update`, and now get it from the default value instead.

The second part is unambiguous: the `if/else` in `install_nodejs` had two byte-for-byte identical branches.

## What I changed relative to #703

* **No separate version bump.** #703 raised `INSTALLER_VERSION` and `FIXER_VERSION` to 2026-03-03 but left `LIBRARY_VERSION` alone, although its main change is in `installer_library.sh`. On this branch all three are already at 2026-09-06.
* **Updated the description of the variable.** It read `# INSTALL_CMD_UPD_ARGS: Arguments for $INSTALL_CMD to update something`, which is no longer accurate now that it also carries the subcommand.
* Changelog entries fold into the existing 2026-09-06 sections instead of adding a 2026-03-03 heading that would now sort below newer ones.

## Note on the name

`INSTALL_CMD_UPD_ARGS` now holds a subcommand plus arguments, so the `_ARGS` suffix reads a little off. I left the name alone to keep the diff small and reviewable — renaming touches the same four call sites again and is easy to do separately if you prefer it.

## Suggested handling of #703

It has been conflicting since March and cannot be merged as it stands. If you take this, #703 can be closed with a pointer here so the attribution stays visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M4gDpoBsbSDNye88UpSWPm
