### PR TITLE
CI: add a job that actually exercises install_nodejs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,3 +62,66 @@ jobs:
         done
         echo "admin did not become reachable within 180s"
         exit 1
+
+  # ===================
+  # Exercises install_nodejs, which no CI run has ever reached: installer.sh only calls it
+  # when "node" is absent, and every runner image ships with Node.js preinstalled. The
+  # NodeSource path - GPG key import, nodesource.sources, apt pinning - was therefore
+  # completely uncovered. Remove Node.js first so the installer has to install it itself.
+  test-nodejs-install:
+    if: contains(github.event.head_commit.message, '[skip ci]') == false
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v7
+
+    # Must happen before Node.js is removed, "node tasks --create" needs it
+    - name: Build the self-contained installer
+      run: node tasks --create
+
+    - name: Remove the preinstalled Node.js
+      run: |
+        sudo apt-get remove -y --purge nodejs npm > /dev/null 2>&1 || true
+        sudo rm -f /usr/local/bin/node /usr/local/bin/npm /usr/local/bin/npx /usr/local/bin/corepack
+        # The tool cache copy is reachable only through the PATH entries the runner sets up
+        printf 'PATH=%s\n' "$(printf '%s' "$PATH" | tr ':' '\n' | grep -v 'hostedtoolcache/node' | paste -sd:)" >> "$GITHUB_ENV"
+
+    # GITHUB_ENV only takes effect in later steps, so assert in a separate one
+    - name: Verify Node.js is really gone
+      run: |
+        if command -v node; then
+          echo "node is still on PATH, the installer would skip install_nodejs"
+          exit 1
+        fi
+        echo "no node on PATH, install_nodejs will run"
+
+    - name: Install ioBroker
+      run: bash ./dist/install.sh --silent
+
+    - name: Verify the installer installed the recommended Node.js from NodeSource
+      run: |
+        expected=$(jq -r '.nodeJsRecommended' versions.json)
+        actual=$(node -v)
+        actual="${actual#v}"
+        actual="${actual%%.*}"
+        echo "installer produced Node.js $actual, versions.json recommends $expected"
+        test "$actual" = "$expected"
+        test -f /etc/apt/sources.list.d/nodesource.sources
+        echo "NodeSource repository is configured"
+
+    - name: Test permissions
+      run: bash .github/testFiles.sh
+
+    - name: Test if ioBroker starts by checking the admin adapter output
+      run: |
+        for i in $(seq 1 36); do
+          if curl -s --insecure http://127.0.0.1:8081 | grep -q '<title>Admin</title>'; then
+            echo "admin is reachable after $((i * 5))s"
+            exit 0
+          fi
+          sleep 5
+        done
+        echo "admin did not become reachable within 180s"
+        exit 1


### PR DESCRIPTION
**Stacked on #741.** Deliberately not on #742: this job does not use the version matrix, and #741 is green, so the first run shows whether the NodeSource path itself works instead of drowning in #742's expected failures. It touches the same file as #742, so whichever lands second needs a small rebase — happy to do that.

## The gap

`installer.sh` calls `install_nodejs` only when `node` is missing:

```bash
if [[ $(type -P "node" 2>/dev/null) != *"/node" ]]; then
    install_nodejs
fi
```

Every GitHub and Cirrus runner image ships with Node.js preinstalled, so **that branch has never been taken in CI, on any platform, ever**. The NodeSource path is uncovered end to end: GPG key download and fingerprint handling, the deb822 `nodesource.sources` file, the apt pin at priority 1001. That is the code most exposed to upstream changes at NodeSource, and the least tested.

## The job

Removes Node.js, then makes the installer put it back:

1. **Build first.** `node tasks --create` needs node, so `dist/install.sh` is built before the removal.
2. **Remove it properly.** Purging the apt packages is not enough — the runner's actual Node.js lives in the tool cache and is reachable through `PATH`. The job purges `nodejs`/`npm`, drops the `/usr/local/bin` symlinks and strips `hostedtoolcache/node` entries from `PATH`:
   ```
   before: /opt/hostedtoolcache/node/20.18.1/x64/bin:/usr/local/bin:/usr/bin:/bin:/opt/hostedtoolcache/node/22/x64/bin
   after:  /usr/local/bin:/usr/bin:/bin
   ```
3. **Assert it is gone**, in a separate step because `GITHUB_ENV` only applies to later ones. Without this the job would quietly degrade into a second copy of `test-install` — the same failure mode as the decorative matrix in #742, so it gets the same kind of guard.
4. **Assert the outcome**: the installed major matches `nodeJsRecommended` from `versions.json`, and `/etc/apt/sources.list.d/nodesource.sources` exists. Verified locally:
   ```
   recommended=22  node -v=v22.11.0  -> PASS
   recommended=22  node -v=v20.18.1  -> FAIL
   recommended=24  node -v=v24.3.0   -> PASS
   ```
5. Then the usual permission and admin checks, with the same retry as `test-install`.

ubuntu only: `install_nodejs` exits under brew, and the macOS runner has no apt to install from.

## What the first run tells us

If it goes red, that is a real finding rather than a CI defect — it means the NodeSource path is broken and nobody could have noticed. I will report either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M4gDpoBsbSDNye88UpSWPm
