### PR TITLE
Fix FreeBSD: ioBroker never started after installation

### DIFF
--- a/CHANGELOG_INSTALLER_LINUX.md
+++ b/CHANGELOG_INSTALLER_LINUX.md
@@ -5,6 +5,7 @@
 * Replace an installed Node.js version that is not listed in nodeJsAccepted instead of only checking that node exists
 * Dropped Node.js 18 and 20 from the accepted versions, iobroker.admin requires Node.js 22 or newer
 * Moved the update subcommand into INSTALL_CMD_UPD_ARGS and removed the duplicated package manager branches
+* FreeBSD: fixed the rc.d pid file path, the IP detection and two sed calls that used the GNU form
 
 ## 2026-04-11
 * Muted some confusing error messages.

--- a/CHANGELOG_INSTALLER_LINUX.md
+++ b/CHANGELOG_INSTALLER_LINUX.md
@@ -5,7 +5,7 @@
 * Replace an installed Node.js version that is not listed in nodeJsAccepted instead of only checking that node exists
 * Dropped Node.js 18 and 20 from the accepted versions, iobroker.admin requires Node.js 22 or newer
 * Moved the update subcommand into INSTALL_CMD_UPD_ARGS and removed the duplicated package manager branches
-* FreeBSD: fixed the rc.d pid file path, the IP detection and two sed calls that used the GNU form
+* FreeBSD: ioBroker now actually starts after the installation, plus fixes to the rc.d pid file path, the IP detection and three sed calls that used the GNU form
 
 ## 2026-04-11
 * Muted some confusing error messages.

--- a/installer.sh
+++ b/installer.sh
@@ -532,11 +532,11 @@ elif [ "$INITSYSTEM" = "rc.d" ]; then
     $SUDOX touch "$PIDFILE"
     $SUDOX chown "$IOB_USER":"$IOB_USER" "$PIDFILE"
 
-    # Enable startup and start the service
+    # Enable autostart only. The service itself is started further below, after
+    # fix_dir_permissions: unlike the systemd unit, which carries Restart=on-failure,
+    # rc.d has no supervision, so a controller started before the ownership of the
+    # installation is changed under it dies and never comes back.
     sysrc iobroker_enable=YES
-    if [ "$SKIP_IOBROKER_START" != "true" ]; then
-        service iobroker start
-    fi
 
     echo "Autostart enabled!"
     echo "Autostart: rc.d" >>"$INSTALLER_INFO_FILE"
@@ -601,7 +601,12 @@ if [ -f /etc/rc.local ]; then
         if [ "$IS_ROOT" != true ]; then
             sudo sed -i 's/curl -sLf https:\/\/iobroker.net\/install\.sh | bash -//g' /etc/rc.local
         else
-            sed -i 's/curl -sLf https:\/\/iobroker.net\/install\.sh | bash -//g' /etc/rc.local
+            # FreeBSD sed needs an explicit backup extension after -i
+            if [ "$HOST_PLATFORM" = "freebsd" ]; then
+                sed -i '' 's/curl -sLf https:\/\/iobroker.net\/install\.sh | bash -//g' /etc/rc.local
+            else
+                sed -i 's/curl -sLf https:\/\/iobroker.net\/install\.sh | bash -//g' /etc/rc.local
+            fi
         fi
     fi
 fi
@@ -617,6 +622,12 @@ get_platform_params
 # Don't do it on OSX, because we'll install as the current user anyways
 if [ "$HOST_PLATFORM" != "osx" ]; then
     fix_dir_permissions
+fi
+
+# Started here, not next to sysrc above, so the ownership of the installation is final
+# before the controller touches it. See the comment in the rc.d block.
+if [ "$INITSYSTEM" = "rc.d" ] && [ "$SKIP_IOBROKER_START" != "true" ]; then
+    service iobroker start
 fi
 # Force npm to run as iobroker when inside IOB_DIR
 if [[ "$IS_ROOT" != true && "$USER" != "$IOB_USER" ]]; then

--- a/installer.sh
+++ b/installer.sh
@@ -473,7 +473,10 @@ elif [ "$INITSYSTEM" = "systemd" ]; then
 elif [ "$INITSYSTEM" = "rc.d" ]; then
     echo "Enabling autostart..."
 
-    PIDFILE="$CONTROLLER_DIR/lib/iobroker.pid"
+    # Was $CONTROLLER_DIR/lib/iobroker.pid, but js-controller has no lib directory any
+    # more, so touch and chown both failed. /var/run is where FreeBSD keeps pid files,
+    # and unlike node_modules it survives an npm install.
+    PIDFILE="/var/run/iobroker.pid"
 
     # Write an rc.d service that automatically detects the correct node executable and runs ioBroker
     RCD_FILE=$(

--- a/installer_library.sh
+++ b/installer_library.sh
@@ -343,9 +343,10 @@ install_necessary_packages() {
         # ensure dns_sd.h is where node-gyp expect it
         ln -s /usr/local/include/avahi-compat-libdns_sd/dns_sd.h /usr/include/dns_sd.h
         # enable dbus in the avahi configuration
-        sed -i -e 's/#enable-dbus/enable-dbus/' /usr/local/etc/avahi/avahi-daemon.conf
+        # FreeBSD sed needs an explicit backup extension after -i, GNU sed does not
+        sed -i '' -e 's/#enable-dbus/enable-dbus/' /usr/local/etc/avahi/avahi-daemon.conf
         # enable mdns usage for host resolution
-        sed -i -e 's/hosts: file dns/hosts: file dns mdns/' /etc/nsswitch.conf
+        sed -i '' -e 's/hosts: file dns/hosts: file dns mdns/' /etc/nsswitch.conf
 
         # enable services avahi/dbus
         sysrc -f /etc/rc.conf dbus_enable="YES"
@@ -955,7 +956,11 @@ detect_ip_address() {
     # Detect IP address - ensure only one IP is returned
     local IP
     IP_COMMAND=$(type "ip" &>/dev/null && echo "ip addr show" || echo "ifconfig")
-    if [ "$HOST_PLATFORM" = "osx" ]; then
+    # Keyed on the command actually used, not on the platform: ifconfig (macOS, FreeBSD,
+    # and any Linux without iproute2) prints "inet 10.0.0.5 netmask ...", while
+    # "ip addr show" prints "inet 10.0.0.5/24 ...". FreeBSD used to take the CIDR branch,
+    # which never matches, so the installer ended with "Open http://:8081".
+    if [ "$IP_COMMAND" = "ifconfig" ]; then
         IP=$($IP_COMMAND | grep inet | grep -v inet6 | grep -v 127.0.0.1 | grep -Eo "([0-9]+\.){3}[0-9]+" | head -1)
     else
         IP=$($IP_COMMAND | grep inet | grep -v inet6 | grep -v 127.0.0.1 | grep -Eo "([0-9]+\.){3}[0-9]+\/[0-9]+" | cut -d "/" -f1 | head -1)


### PR DESCRIPTION
**Stacked on #743.** Found by the FreeBSD job in #745, which ran that platform for the first time since Cirrus stopped producing check runs in 2024.

## The root cause

ioBroker did not start on FreeBSD after an installation. Not slowly — at all: no controller process, no log file, and `service iobroker start` returned without a single line of output.

`installer.sh` did this:

| line | |
| --- | --- |
| 517 | `service iobroker start` |
| 598 | `fix_dir_permissions` — chowns the whole tree under `/opt/iobroker` |

The controller is launched, and the ownership of the entire installation is then changed underneath it while it is still starting.

**Linux survives this by accident.** The generated systemd unit carries:

```ini
Restart=on-failure
RestartSec=3s
```

so a controller killed that way is back three seconds later and nobody ever notices. The generated rc.d script contains no `Restart` directive — no supervision whatsoever — so on FreeBSD the process simply stayed dead, quietly.

The rc.d start now happens after `fix_dir_permissions`. The systemd path is deliberately left alone: the ordering is just as questionable there, but it is masked by `Restart=on-failure`, and changing it would alter behaviour on the platform that actually has coverage.

## Verification

The check that proves this **only observes** — it never starts anything itself, so the result cannot be self-fulfilling. That distinction matters here: an earlier run of mine looked green only because the diagnostics had started the service before the admin check.

```
node: iobroker.js-controller (node)
the installer started ioBroker on its own
admin is reachable after 5s
FreeBSD installation test finished successfully
```

The full test also covers `iobroker url iobroker.lovelace` (the python dependency), stopping the controller, running `dist/fix.sh`, and re-checking file permissions.

## Four more FreeBSD-only defects fixed along the way

* **`installer.sh`** — `PIDFILE` was `$CONTROLLER_DIR/lib/iobroker.pid`. js-controller has no `lib` directory any more, so `touch` and `chown` both failed. Moved to `/var/run/iobroker.pid`, which is where FreeBSD keeps pid files and, unlike `node_modules`, survives an `npm install`. Only the rc.d path uses `PIDFILE`, which is why systemd runs never showed it.
* **`installer_library.sh`** — `detect_ip_address` branched on the platform and put FreeBSD on the Linux side, matching CIDR notation that `ifconfig` never prints, so the installer ended with `Open http://:8081`. It now branches on the command whose output is actually parsed, which also covers a Linux system without iproute2:
  ```
  ifconfig      (FreeBSD/macOS format) -> [192.168.122.10]
  ip addr show  (Linux format)         -> [192.168.122.10]
  ```
* **`installer_library.sh`** — two `sed -i` calls in the FreeBSD-only branch used the GNU form. FreeBSD sed requires an explicit backup extension and failed with `-I or -i may not be used with stdin`, leaving dbus disabled in the avahi configuration and mdns missing from nsswitch.
* **`installer.sh`** — a third `sed -i` of the same kind, on `/etc/rc.local`.

## Sequencing

The FreeBSD job lives in #745 and is currently marked `continue-on-error` because the platform was broken. Once this and #745 are both on master, that line should come out — happy to send the one-line follow-up.

Note that none of this is reachable from the Linux CI: every defect here is either FreeBSD-only code or Linux-masked. It stayed hidden for as long as nothing ran that platform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M4gDpoBsbSDNye88UpSWPm
